### PR TITLE
Cache cluster models

### DIFF
--- a/crosscat/utils/inference_utils.py
+++ b/crosscat/utils/inference_utils.py
@@ -38,11 +38,11 @@ def mutual_information_to_linfoot(MI):
 
 # return the estimated mutual information for each pair of columns on Q given
 # the set of samples in X_Ls and X_Ds. Q is a list of tuples where each tuple
-# contains X and Y, the columns to compare. 
+# contains X and Y, the columns to compare.
 # Q = [(X_1, Y_1), (X_2, Y_2), ..., (X_n, Y_n)]
 # Returns a list of list where each sublist is a set of MI's and Linfoots from
-# each crosscat posterior sample. 
-# See tests/test_mutual_information.py and 
+# each crosscat posterior sample.
+# See tests/test_mutual_information.py and
 # tests/test_mutual_information_vs_correlation.py for useage examples
 def mutual_information(M_c, X_Ls, X_Ds, Q, n_samples=1000):
     #
@@ -68,9 +68,9 @@ def mutual_information(M_c, X_Ls, X_Ds, Q, n_samples=1000):
 
         MI_sample = []
         Linfoot_sample = []
-        
+
         for sample in range(n_postertior_samples):
-            
+
             X_L = X_Ls[sample]
             X_D = X_Ds[sample]
 
@@ -81,7 +81,7 @@ def mutual_information(M_c, X_Ls, X_Ds, Q, n_samples=1000):
                 MI_s = estimiate_MI_sample(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=n_samples)
 
             linfoot = mutual_information_to_linfoot(MI_s)
-            
+
             MI_sample.append(MI_s)
 
             Linfoot_sample.append(linfoot)
@@ -89,7 +89,7 @@ def mutual_information(M_c, X_Ls, X_Ds, Q, n_samples=1000):
         MI.append(MI_sample)
         Linfoot.append(Linfoot_sample)
 
-         
+
     assert(len(MI) == len(Q))
     assert(len(Linfoot) == len(Q))
 
@@ -140,7 +140,7 @@ def calculate_MI_bounded_discrete(X, Y, M_c, X_L, X_D):
                 Py[j] = component_models_Y[j].calc_element_predictive_logp(y)
                 Pxy[j] = Px[j] + Py[j] + cluster_logps[j]   # \sum_c P(x|c)P(y|c)P(c), Joint distribution
                 Px[j] += cluster_logps[j]                   # \sum_c P(x|c)P(c)
-                Py[j] += cluster_logps[j]                   # \sum_c P(y|c)P(c) 
+                Py[j] += cluster_logps[j]                   # \sum_c P(y|c)P(c)
 
             # sum over clusters
             Px = logsumexp(Px)
@@ -152,14 +152,14 @@ def calculate_MI_bounded_discrete(X, Y, M_c, X_L, X_D):
     # ignore MI < 0
     if MI <= 0.0:
         MI = 0.0
-        
+
     return MI
 
 
 
 # estimates the mutual information for columns X and Y.
 def estimiate_MI_sample(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=1000):
-    
+
     get_view_index = lambda which_column: X_L['column_partition']['assignments'][which_column]
 
     view_X = get_view_index(X)
@@ -188,7 +188,7 @@ def estimiate_MI_sample(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=1000):
     weights = numpy.zeros(n_samples)
 
     for i in range(n_samples):
-        # draw a cluster 
+        # draw a cluster
         cluster_idx = numpy.nonzero(numpy.random.multinomial(1, cluster_crps))[0][0]
 
         # get a sample from each cluster
@@ -207,10 +207,10 @@ def estimiate_MI_sample(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=1000):
             Py[j] = component_models_Y[j].calc_element_predictive_logp(y)
             Pxy[j] = Px[j] + Py[j] + cluster_logps[j]   # \sum_c P(x|c)P(y|c)P(c), Joint distribution
             Px[j] += cluster_logps[j]                   # \sum_c P(x|c)P(c)
-            Py[j] += cluster_logps[j]                   # \sum_c P(y|c)P(c)    
+            Py[j] += cluster_logps[j]                   # \sum_c P(y|c)P(c)
 
         # pdb.set_trace()
-        
+
         # sum over clusters
         Px = logsumexp(Px)
         Py = logsumexp(Py)
@@ -230,19 +230,19 @@ def estimiate_MI_sample(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=1000):
     # ignore MI < 0
     if MI_ret <= 0.0:
         MI_ret = 0.0
-        
+
     return MI_ret
 
 # Histogram estimations are biased and shouldn't be used, this is just for testing purposes.
 def estimiate_MI_sample_hist(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=10000):
-    
+
     get_view_index = lambda which_column: X_L['column_partition']['assignments'][which_column]
 
     view_X = get_view_index(X)
     view_Y = get_view_index(Y)
 
     # independent
-    if view_X != view_Y:        
+    if view_X != view_Y:
         return 0.0
 
     # get cluster logps
@@ -266,7 +266,7 @@ def estimiate_MI_sample_hist(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=10000
 
     # draw the samples
     for i in range(n_samples):
-        # draw a cluster 
+        # draw a cluster
         cluster_idx = numpy.nonzero(numpy.random.multinomial(1, cluster_crps))[0][0]
 
         x = component_models_X[cluster_idx].get_draw(get_next_seed())
@@ -296,18 +296,18 @@ def estimiate_MI_sample_hist(X, Y, M_c, X_L, X_D, get_next_seed, n_samples=10000
     MI = 0
 
     for i_x in range(PXY.shape[0]):
-        for i_y in range(PXY.shape[1]):            
+        for i_y in range(PXY.shape[1]):
             Pxy = PXY[i_x,i_y]
             Px = PX[i_x]
             Py = PY[i_y]
-            
+
             if Pxy > 0.0 and Px > 0.0 and Py > 0.0:
                 MI += (Pxy/N)*math.log(Pxy*N/(Px*Py))
-            
+
 
 
     # ignore MI < 0
     if MI <= 0.0:
         MI = 0.0
-        
+
     return MI

--- a/crosscat/utils/sample_utils.py
+++ b/crosscat/utils/sample_utils.py
@@ -17,13 +17,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-import sys
-import copy
-import math
 
+import copy
 from collections import Counter
-
-import copy
 import numpy
 #
 import crosscat.cython_code.ContinuousComponentModel as CCM
@@ -44,7 +40,7 @@ class Bunch(dict):
 
 Constraints = Bunch
 
-# Q is a list of three element tuples where each typle, (r,c,x) contains a
+# Q is a list of three element tuples where each tuple, (r,c,x) contains a
 # row, r; a column, c; and a value x. The contraints, Y follow an identical format.
 # Returns a numpy array where each entry, A[i] is the probability for query i given
 # the contraints in Y.
@@ -55,9 +51,9 @@ def simple_predictive_probability(M_c, X_L, X_D, Y, Q):
     query_columns = [query[1] for query in Q]
     elements = [query[2] for query in Q]
     # enforce query rows all same row
-    assert(all([query[0]==query_row for query in Q]))
+    assert all([query[0]==query_row for query in Q])
     # enforce query columns observed column
-    assert(all([query_column<num_cols for query_column in query_columns]))
+    assert all([query_column<num_cols for query_column in query_columns])
     is_observed_row = query_row < num_rows
 
     x = []
@@ -119,7 +115,7 @@ def simple_predictive_probability_unobserved(M_c, X_L, X_D, Y, query_row, query_
         answers_n = numpy.zeros(len(cluster_logps))
 
         # cluster_logps should logsumexp to log(1)
-        assert(numpy.abs(logsumexp(cluster_logps)) < .0000001)
+        assert numpy.abs(logsumexp(cluster_logps)) < .0000001
 
         # enumerate over the clusters
         for cluster_idx in range(len(cluster_logps)):
@@ -222,9 +218,9 @@ def simple_predictive_sample(M_c, X_L, X_D, Y, Q, get_next_seed, n=1):
     query_row = Q[0][0]
     query_columns = [query[1] for query in Q]
     # enforce query rows all same row
-    assert(all([query[0]==query_row for query in Q]))
+    assert all([query[0]==query_row for query in Q])
     # enforce query columns observed column
-    assert(all([query_column<num_cols for query_column in query_columns]))
+    assert all([query_column<num_cols for query_column in query_columns])
     is_observed_row = query_row < num_rows
     x = []
     if not is_observed_row:
@@ -251,7 +247,7 @@ def simple_predictive_sample(M_c, X_L, X_D, Y, Q, get_next_seed, n=1):
 def simple_predictive_sample_multistate(M_c, X_L_list, X_D_list, Y, Q,
                                         get_next_seed, n=1):
     num_states = len(X_L_list)
-    assert(num_states==len(X_D_list))
+    assert num_states==len(X_D_list)
     n_from_each = n / num_states
     n_sampled = n % num_states
     random_state = numpy.random.RandomState(get_next_seed())
@@ -390,7 +386,7 @@ def create_cluster_model(zipped_column_info, row_partition_model,
 def create_empty_cluster_model(zipped_column_info):
     cluster_component_models = dict()
     for global_column_idx in zipped_column_info:
-        column_metadata, column_hypers, column_component_suffstats = \
+        column_metadata, column_hypers, _column_component_suffstats = \
             zipped_column_info[global_column_idx]
         component_model = create_component_model(column_metadata,
                                                  column_hypers, dict(N=None))
@@ -456,13 +452,13 @@ def get_draw_constraints(X_L, X_D, Y, draw_row, draw_column):
         X_D_i = X_D[view_idx]
         try:
             draw_cluster = X_D_i[draw_row]
-        except IndexError, e:
+        except IndexError:
             draw_cluster = None
         for constraint in Y:
             constraint_row, constraint_col, constraint_value = constraint
             try:
                 constraint_cluster = X_D_i[constraint_row]
-            except IndexError, e:
+            except IndexError:
                 constraint_cluster = None
             if (constraint_col == draw_column) \
                     and (constraint_cluster == draw_cluster):
@@ -527,7 +523,7 @@ def create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx):
     zipped_column_info, row_partition_model = extract_view_column_info(
         M_c, X_L, view_idx)
     num_clusters = len(row_partition_model['counts'])
-    if(cluster_idx==num_clusters):
+    if cluster_idx==num_clusters:
         # drew a new cluster
         cluster_model = create_empty_cluster_model(zipped_column_info)
     else:
@@ -674,7 +670,7 @@ def continuous_imputation_confidence(samples, imputed,
         X_L_list = []
         X_D_list = []
 
-    for chain in range(n_chains):
+    for _ in range(n_chains):
         ccstate = State.p_State(M_c, T)
         ccstate.transition(which_transitions=tlist, n_steps=n_steps)
 
@@ -729,11 +725,11 @@ modeltype_to_imputation_confidence_function = {
 
 def impute(M_c, X_L, X_D, Y, Q, n, get_next_seed, return_samples=False):
     # FIXME: allow more than one cell to be imputed
-    assert(len(Q)==1)
+    assert len(Q)==1
     #
     col_idx = Q[0][1]
     modeltype = M_c['column_metadata'][col_idx]['modeltype']
-    assert(modeltype in modeltype_to_imputation_function)
+    assert modeltype in modeltype_to_imputation_function
     if get_is_multistate(X_L, X_D):
         samples = simple_predictive_sample_multistate(M_c, X_L, X_D, Y, Q,
                                            get_next_seed, n)
@@ -780,7 +776,7 @@ def get_column_component_suffstats_i(M_c, X_L, col_idx):
 
 def impute_and_confidence(M_c, X_L, X_D, Y, Q, n, get_next_seed):
     # FIXME: allow more than one cell to be imputed
-    assert(len(Q)==1)
+    assert len(Q)==1
     col_idx = Q[0][1]
     modeltype = M_c['column_metadata'][col_idx]['modeltype']
     imputation_confidence_function = \

--- a/crosscat/utils/sample_utils.py
+++ b/crosscat/utils/sample_utils.py
@@ -519,7 +519,29 @@ def sample_from_cluster(cluster_model, random_state):
         sample.append(sample_i)
     return sample
 
+# LRU replacement, size 1
+__cache = (-1, None)
+def _cache_for(M_c):
+    global __cache
+    (cur_id, cur_cache) = __cache
+    if cur_id == id(M_c):
+        return cur_cache
+    else:
+        ans = {}
+        __cache = (id(M_c), ans)
+        return ans
+
 def create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx):
+    cache = _cache_for(M_c)
+    key = ('cluster_model', id(X_L), view_idx, cluster_idx)
+    if key in cache:
+        return cache[key]
+    else:
+        ans = do_create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx)
+        cache[key] = ans
+        return ans
+
+def do_create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx):
     zipped_column_info, row_partition_model = extract_view_column_info(
         M_c, X_L, view_idx)
     num_clusters = len(row_partition_model['counts'])

--- a/crosscat/utils/sample_utils.py
+++ b/crosscat/utils/sample_utils.py
@@ -525,12 +525,10 @@ def create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx):
     num_clusters = len(row_partition_model['counts'])
     if cluster_idx==num_clusters:
         # drew a new cluster
-        cluster_model = create_empty_cluster_model(zipped_column_info)
+        return create_empty_cluster_model(zipped_column_info)
     else:
-        cluster_model = create_cluster_model(
-            zipped_column_info, row_partition_model, cluster_idx
-            )
-    return cluster_model
+        return create_cluster_model(
+            zipped_column_info, row_partition_model, cluster_idx)
 
 def simple_predictive_sample_unobserved(M_c, X_L, X_D, Y, query_row,
                                         query_columns, get_next_seed, n=1):

--- a/crosscat/utils/sample_utils.py
+++ b/crosscat/utils/sample_utils.py
@@ -282,17 +282,10 @@ def simple_predictive_sample_observed(M_c, X_L, X_D, Y, which_row,
     #
     def view_for(column):
         return X_L['column_partition']['assignments'][column]
-    cluster_model_cache = dict()
     def cluster_model_for(view):
-        if view in cluster_model_cache:
-            return cluster_model_cache[view]
-        else:
-            cluster = X_D[view][which_row]
-            # pull the suffstats, hypers, and marignal logP's for clusters
-            cluster_model = create_cluster_model_from_X_L(
-                M_c, X_L, view, cluster)
-            cluster_model_cache[view] = cluster_model
-            return cluster_model
+        cluster = X_D[view][which_row]
+        # pull the suffstats, hypers, and marignal logP's for clusters
+        return create_cluster_model_from_X_L(M_c, X_L, view, cluster)
     def component_model_for(column):
         return cluster_model_for(view_for(column))[column]
     samples_list = []
@@ -568,15 +561,8 @@ def simple_predictive_sample_unobserved(M_c, X_L, X_D, Y, query_row,
         dict((col, val) for row, col, val in Y if row == query_row)
     def view_for(column):
         return X_L['column_partition']['assignments'][column]
-    cluster_model_cache = dict()
     def cluster_model_for(view, cluster):
-        if (view, cluster) in cluster_model_cache:
-            return cluster_model_cache[(view, cluster)]
-        else:
-            cluster_model = create_cluster_model_from_X_L(
-                M_c, X_L, view, cluster)
-            cluster_model_cache[(view, cluster)] = cluster_model
-            return cluster_model
+        return create_cluster_model_from_X_L(M_c, X_L, view, cluster)
     samples_list = []
     for _ in range(n):
         view_cluster_draws = dict()


### PR DESCRIPTION
Redundant calls to create_cluster_model_from_X_L were the speed bottleneck on both of the queries from the Satellites demo that I have profiled.  I added a global cache for them, keyed on the identity of the metadata and X_L objects and the value of the view index and cluster index.

This change speeds up large predictive probability computations (e.g., every satellite's period) by around 10x, and replaces the local caches I had added to simple_predictive_sample_{observed/unobserved} (which themselves sped up 1000-row simulations by around 15x).

Potential down side: The cache will retain the built cluster models in memory, potentially past the point at which the garbage collector could prove that they cannot be needed in the future.  Why?
- I don't think it's a problem yet, given my mitigation of only storing the last used crosscat metadata object
- I don't trust Python's weak references enough to do this the way I would do it in MIT Scheme if I were being careful