### PR TITLE
Drop some unused C++ code and clean up warnings.

### DIFF
--- a/cpp_code/Makefile
+++ b/cpp_code/Makefile
@@ -1,3 +1,4 @@
+CXXOPTS := $(CXXOPTS) -Wall -Werror -std=c++03
 OPTIMIZED = True
 ifdef OPTIMIZED
 CXXOPTS := -pg -O2 $(CXXOPTS)

--- a/cpp_code/include/CrossCat/ComponentModel.h
+++ b/cpp_code/include/CrossCat/ComponentModel.h
@@ -38,25 +38,25 @@ public:
     CM_Hypers get_hypers() const;
     int get_count() const;
     std::map<std::string, double> get_suffstats() const;
-    virtual std::map<std::string, double> _get_suffstats() const;
-    virtual double get_draw(int random_seed) const;
-    virtual double get_draw_constrained(int random_seed,
-                                const std::vector<double>& constraints) const;
+    virtual std::map<std::string, double> _get_suffstats() const = 0;
+    virtual double get_draw(int random_seed) const = 0;
+    virtual double get_draw_constrained(
+        int random_seed, const std::vector<double>& constraints) const = 0;
     //
     //
     // calculators
-    virtual double calc_marginal_logp() const;
-    virtual double calc_element_predictive_logp(double element) const;
+    virtual double calc_marginal_logp() const = 0;
+    virtual double calc_element_predictive_logp(double element) const = 0;
     virtual double calc_element_predictive_logp_constrained(double element,
-            const std::vector<double>& constraints) const;
+            const std::vector<double>& constraints) const = 0;
     virtual std::vector<double> calc_hyper_conditionals(
             const std::string& which_hyper,
-            const std::vector<double>& hyper_grid) const;
+            const std::vector<double>& hyper_grid) const = 0;
     //
     // mutators
-    virtual double insert_element(double element);
-    virtual double remove_element(double element);
-    virtual double incorporate_hyper_update();
+    virtual double insert_element(double element) = 0;
+    virtual double remove_element(double element) = 0;
+    virtual double incorporate_hyper_update() = 0;
     //
     // helpers
     friend std::ostream& operator<<(std::ostream& os, const ComponentModel& cm);
@@ -69,8 +69,8 @@ protected:
     double score;
     //
     // helpers
-    virtual void set_log_Z_0();
-    virtual void init_suffstats();
+    virtual void set_log_Z_0() = 0;
+    virtual void init_suffstats() = 0;
 private:
 };
 

--- a/cpp_code/include/CrossCat/constants.h
+++ b/cpp_code/include/CrossCat/constants.h
@@ -24,7 +24,6 @@
 #include <string>
 
 static const int MAX_INT = std::numeric_limits<int>::max();
-static const double NaN = 0. / 0.;
 static const std::string MULTINOMIAL_DATATYPE = "symmetric_dirichlet_discrete";
 static const std::string CONTINUOUS_DATATYPE = "normal_inverse_gamma";
 static const std::string CYCLIC_DATATYPE = "vonmises";

--- a/cpp_code/include/CrossCat/utils.h
+++ b/cpp_code/include/CrossCat/utils.h
@@ -108,13 +108,6 @@ std::vector<T> append(const std::vector<T>& vec1, const std::vector<T>& vec2) {
 }
 
 template <class K, class V>
-bool in(const std::map<K, V>& m, const K& key) {
-    typename std::map<K, V>::const_iterator it = m.find(key);
-    bool is_in = it != m.end();
-    return is_in;
-}
-
-template <class K, class V>
 V setdefault(std::map<K, V>& m, const K& key, const V& value) {
     typename std::map<K, V>::const_iterator it = m.find(key);
     if (it == m.end())

--- a/cpp_code/include/CrossCat/utils.h
+++ b/cpp_code/include/CrossCat/utils.h
@@ -307,9 +307,6 @@ int count_elements(const std::vector<std::vector<T> >& v_v_T) {
     return num_elements;
 }
 
-bool is_bad_value(double value);
-bool isnan(const std::string& value);
-
 #define DISALLOW_COPY_AND_ASSIGN(CLASS)         \
   CLASS(const CLASS&);                          \
   void operator=(const CLASS&)

--- a/cpp_code/src/Cluster.cpp
+++ b/cpp_code/src/Cluster.cpp
@@ -122,8 +122,7 @@ double Cluster::calc_column_predictive_logp(const vector<double>& column_data,
         const CM_Hypers& hypers) {
     // FIXME: global_to_data must be used if not all rows are present
     // map<int, int> global_to_data = construct_lookup_map(data_global_row_indices);
-    ComponentModel prevent_warning;
-    ComponentModel *p_cm = &prevent_warning;
+    ComponentModel *p_cm = NULL;
     if (col_datatype == CONTINUOUS_DATATYPE) {
         p_cm = new ContinuousComponentModel(hypers);
     } else if (col_datatype == CYCLIC_DATATYPE) {
@@ -203,8 +202,7 @@ double Cluster::insert_col(const vector<double>& data,
                            const CM_Hypers& hypers) {
     // FIXME: global_to_data must be used if not all rows are present
     // map<int, int> global_to_data = construct_lookup_map(data_global_row_indices);
-    ComponentModel prevent_warning;
-    ComponentModel *p_cm = &prevent_warning;
+    ComponentModel *p_cm = NULL;
     if (col_datatype == CONTINUOUS_DATATYPE) {
         p_cm = new ContinuousComponentModel(hypers);
     } else if (col_datatype == MULTINOMIAL_DATATYPE) {
@@ -213,8 +211,7 @@ double Cluster::insert_col(const vector<double>& data,
         p_cm = new CyclicComponentModel(hypers);
     } else {
         cout << "ERROR: Cluster::insert_col: col_datatype=" << col_datatype << endl;
-        assert(1 == 0);
-        exit(EXIT_FAILURE);
+        abort();
     }
     set<int>::const_iterator it;
     for (it = row_indices.begin(); it != row_indices.end(); ++it) {

--- a/cpp_code/src/Cluster.cpp
+++ b/cpp_code/src/Cluster.cpp
@@ -261,15 +261,15 @@ void Cluster::init_columns(const vector<CM_Hypers*>& hypers_v) {
     for (it = hypers_v.begin(); it != hypers_v.end(); ++it) {
         CM_Hypers& hypers = **it;
         ComponentModel *p_cm;
-        if (in(hypers, continuous_key)) {
+        if (hypers.count(continuous_key)) {
             // FIXME: should be passed col_datatypes here
             //         and instantiate correct type?
             p_cm = new ContinuousComponentModel(hypers);
             p_model_v.push_back(p_cm);
-        } else if (in(hypers, multinomial_key)){
+        } else if (hypers.count(multinomial_key)) {
             p_cm = new MultinomialComponentModel(hypers);
             p_model_v.push_back(p_cm);
-        } else if (in(hypers, cyclic_key)) {
+        } else if (hypers.count(cyclic_key)) {
             p_cm = new CyclicComponentModel(hypers);
             p_model_v.push_back(p_cm);
         } else {

--- a/cpp_code/src/ComponentModel.cpp
+++ b/cpp_code/src/ComponentModel.cpp
@@ -21,60 +21,6 @@
 
 using namespace std;
 
-// virtuals that should be component model specific
-double ComponentModel::calc_marginal_logp() const {
-    assert(0);
-    return NaN;
-}
-double ComponentModel::calc_element_predictive_logp(double element) const {
-    assert(0);
-    return NaN;
-}
-double ComponentModel::calc_element_predictive_logp_constrained(double element,
-        const vector<double>& constraints) const {
-    assert(0);
-    return NaN;
-}
-vector<double> ComponentModel::calc_hyper_conditionals(const string& which_hyper,
-        const vector<double>& hyper_grid) const {
-    assert(0);
-    vector<double> vd;
-    return vd;
-}
-map<string, double> ComponentModel::_get_suffstats() const {
-    assert(0);
-    map<string, double> suffstats;
-    return suffstats;
-}
-double ComponentModel::get_draw(int random_seed) const {
-    assert(0);
-    return NaN;
-}
-double ComponentModel::get_draw_constrained(int random_seed,
-        const vector<double>& constraints) const {
-    assert(0);
-    return NaN;
-}
-//
-double ComponentModel::insert_element(double element) {
-    assert(0);
-    return NaN;
-}
-double ComponentModel::remove_element(double element) {
-    assert(0);
-    return NaN;
-}
-double ComponentModel::incorporate_hyper_update() {
-    assert(0);
-    return NaN;
-}
-void ComponentModel::set_log_Z_0() {
-    assert(0);
-}
-void ComponentModel::init_suffstats() {
-    assert(0);
-}
-
 CM_Hypers ComponentModel::get_hypers() const {
     return *p_hypers;
 }

--- a/cpp_code/src/State.cpp
+++ b/cpp_code/src/State.cpp
@@ -992,7 +992,7 @@ void State::init_column_hypers(const vector<int>& global_col_indices) {
             ++gci_it) {
         int global_col_idx = *gci_it;
         hypers_m[global_col_idx] = uniform_sample_hypers(global_col_idx);
-        if (!in(hypers_m[global_col_idx], (string) "fixed")) {
+        if (!hypers_m[global_col_idx].count("fixed")) {
             hypers_m[global_col_idx]["fixed"] = 0;
         }
     }

--- a/cpp_code/src/utils.cpp
+++ b/cpp_code/src/utils.cpp
@@ -468,15 +468,3 @@ void construct_multinomial_base_hyper_grids(int n_grid,
 					    vector<double> &multinomial_alpha_grid) {
   multinomial_alpha_grid = log_linspace(1., data_num_vectors, n_grid);
 }
-
-bool is_bad_value(double value) {
-  return isnan(value) || !isfinite(value);
-}
-
-bool isnan(const string& value_str) {
-  bool isnan = (value_str.compare("NaN") == 0) || (value_str.compare("nan") == 0);
-  if(isnan) {
-    cout << "utils::isnan(" << value_str << ") = True" << endl;
-  }
-  return isnan;
-}

--- a/cpp_code/tests/test_multinomial_component_model.cpp
+++ b/cpp_code/tests/test_multinomial_component_model.cpp
@@ -212,9 +212,8 @@ int main() {
     // cout << "draws are: " << draws << endl;
     cout << "draw_counts is: " << draw_counts << endl;
 
-    double sum_p = 0;
     for (int element = 0; element < NUM_BUCKETS; element++) {
-        double element_p = exp(mcm2.calc_element_predictive_logp(element));
+        mcm2.calc_element_predictive_logp(element);
     }
 
     cout << endl << "End:: test_multinomial_component_model" << endl;

--- a/cpp_code/tests/test_multinomial_component_model.cpp
+++ b/cpp_code/tests/test_multinomial_component_model.cpp
@@ -154,11 +154,7 @@ int main() {
         int rand_int = rng.nexti();
         double draw = mcm.get_draw(rand_int);
         draws.push_back(draw);
-        if (in(draw_counts, draw)) {
-            draw_counts[draw]++;
-        } else {
-            draw_counts[draw] = 1;
-        }
+        draw_counts[draw]++;
     }
     // cout << "draws are: " << draws << endl;
     cout << "draw_counts is: " << draw_counts << endl;
@@ -203,11 +199,7 @@ int main() {
         int rand_int = rng.nexti();
         double draw = mcm2.get_draw(rand_int);
         draws.push_back(draw);
-        if (in(draw_counts, draw)) {
-            draw_counts[draw]++;
-        } else {
-            draw_counts[draw] = 1;
-        }
+        draw_counts[draw]++;
     }
     // cout << "draws are: " << draws << endl;
     cout << "draw_counts is: " << draw_counts << endl;


### PR DESCRIPTION
The bulk of the pull request replaces `ComponentModel` methods that abort with abstract methods.

I also get rid of the `in()` function, clean up some warnings, and turn on `-Werror`.