### PR TITLE
Randomize seeds for chain states better

### DIFF
--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -80,22 +80,12 @@ class MapperContext(object):
             pass
         return False
 
-class int_generator(object):
-    """Int generator with mutex."""
-    def __init__(self, start=None):
-        self.start = start
-        if start is None:
-            self.start = random.randrange(32767)
-        self.next_i = self.start
-        self.lock = threading.Lock()
-
-    def __iter__(self):
-        return self
-
-    def next(self):
-        with self.lock:
-            self.next_i += 1
-            return self.next_i
+def int_generator(start=None):
+    r = random.Random(start if start is not None else 32767)
+    for _ in xrange(10):
+        # This is thread safe because r's state changes in Random.random, which
+        # is C code and therefore constrained by the Global Interpreter Lock.
+        yield r.randint(0, 2147483646)
 
 def roundrobin(*iterables):
     "roundrobin('ABC', 'D', 'EF') --> A D E B F C"

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -92,7 +92,7 @@ def int_generator(prngstate=None):
                             'with a randint method.  (E.g., random.Random '
                             'or numpy.random.RandomState instance.)')
     lock = threading.Lock()
-    for _ in xrange(10):
+    for _ in xrange(2**62):
         with lock:
             yield prngstate.randint(0, 2147483646)
 


### PR DESCRIPTION
shell/main.py initializes the crosscat engine with args.seed, which in
EngineTemplate.__init__ generates a general_utils.int_generator, which
at the moment generates consecutive integers. These are used by
LocalEngine.get_initialize_arg_tuples to generate seeds for the States
which are used to store the MCMC states at each iteration.

This potentially seems like a pretty serious problem: Suppose I start
bayesdb --seed=0, and run a calculation with 60 chains. Then I rerun the
calculation with --seed=1. All but one of the 60 new chains will have
been initialized with a seed used in the prior run.

The same issue applies to programmatic use of crosscat/bayeslite.

This patch corrects that issue by having int_generator yield values from
an RNG instead.