### PR TITLE
Release the GIL, crosscat!!! 

### DIFF
--- a/cpp_code/include/CrossCat/StateNoGIL.h
+++ b/cpp_code/include/CrossCat/StateNoGIL.h
@@ -92,8 +92,13 @@ class StateNoGIL {
     double draw_rand_i();
     std::string to_string(const std::string& join_str = "\n",
                           bool top_level = false) const;
+    // XXX: These must be initialized in cython. They need to be class-level,
+    // therefore "static", but to be useful they can't be "const".
+    static bool release_GIL;
  private:
     State *state;
+    static void start_thread();
+    static void end_thread();
 };
 
 #endif  // GUARD_stateNoGIL_h

--- a/cpp_code/include/CrossCat/StateNoGIL.h
+++ b/cpp_code/include/CrossCat/StateNoGIL.h
@@ -92,13 +92,16 @@ class StateNoGIL {
     double draw_rand_i();
     std::string to_string(const std::string& join_str = "\n",
                           bool top_level = false) const;
-    // XXX: These must be initialized in cython. They need to be class-level,
-    // therefore "static", but to be useful they can't be "const".
+    // Flag for whether to release the GIL on a call to a crosscat function.
+    // This must be initialized outside the class definition. It needs to be
+    // class-level, therefore "static", but to be useful it can't be "const".
+    // It's defined in StateNoGIL.cpp. It can't be defined in State.h, because
+    // State.h is included in the separate compilations of
+    // cpp_code/src/State.cpp and the product of State.pyx, and
+    // GUARD_stateNoGIL_h is undefined both times.
     static bool release_GIL;
  private:
     State *state;
-    static void start_thread();
-    static void end_thread();
 };
 
 #endif  // GUARD_stateNoGIL_h

--- a/cpp_code/include/CrossCat/StateNoGIL.h
+++ b/cpp_code/include/CrossCat/StateNoGIL.h
@@ -1,0 +1,99 @@
+#ifndef GUARD_stateNoGIL_h
+#define GUARD_stateNoGIL_h
+
+#include <set>
+#include <vector>
+#include "View.h"
+#include "utils.h"
+#include "constants.h"
+#include <fstream>
+#include <iostream>
+#include <algorithm>
+#include <cmath>   // for log()
+#include <limits>
+#include "Matrix.h"
+
+#include "Python.h"
+#include "State.h"
+
+// Wraps CrossCat State methods with logic releasing the Python GIL in cases
+// where significant computation could be done. See State.h for descriptions of
+// wrapped functions.
+
+// Only functions referenced by State.pyx have been wrapped
+
+class StateNoGIL {
+ public:
+    StateNoGIL(const MatrixD& data,
+               const std::vector<std::string>& GLOBAL_COL_DATATYPES,
+               const std::vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
+               const std::vector<int>& global_row_indices,
+               const std::vector<int>& global_col_indices,
+               const std::map<int, CM_Hypers>& HYPERS_M,
+               const std::vector<std::vector<int> >& column_partition,
+               const std::map<int, std::set<int> >& col_ensure_dep,
+               const std::map<int, std::set<int> >& col_ensure_ind,
+               double COLUMN_CRP_ALPHA,
+               const std::vector<std::vector<std::vector<int> > >& row_partition_v,
+               const std::vector<double>& row_crp_alpha_v,
+               const std::vector<double>& ROW_CRP_ALPHA_GRID = empty_vector_double,
+               const std::vector<double>& COLUMN_CRP_ALPHA_GRID = empty_vector_double,
+               const std::vector<double>& S_GRID = empty_vector_double,
+               const std::vector<double>& MU_GRID = empty_vector_double,
+               int N_GRID=31, int SEED=0, int CT_KERNEL=0);
+    StateNoGIL(const MatrixD& data,
+               const std::vector<std::string>& GLOBAL_COL_DATATYPES,
+               const std::vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
+               const std::vector<int>& global_row_indices,
+               const std::vector<int>& global_col_indices,
+               const std::string& col_initialization = FROM_THE_PRIOR,
+               std::string row_initialization = "",
+               const std::vector<double>& ROW_CRP_ALPHA_GRID = empty_vector_double,
+               const std::vector<double>& COLUMN_CRP_ALPHA_GRID = empty_vector_double,
+               const std::vector<double>& S_GRID = empty_vector_double,
+               const std::vector<double>& MU_GRID = empty_vector_double,
+               int N_GRID=31, int SEED=0, int CT_KERNEL=0);
+    ~StateNoGIL();
+    int get_num_views() const;
+    double insert_row(const std::vector<double>& row_data, int matching_row_idx,
+                      int row_idx=-1);
+    double get_column_crp_alpha() const;
+    double get_column_crp_score() const;
+    double transition_features(const MatrixD& data,
+                               std::vector<int> which_features);
+     double get_data_score() const;
+    double get_marginal_logp() const;
+    std::map<std::string, double> get_row_partition_model_hypers_i(int view_idx ) const;
+    std::vector<int> get_row_partition_model_counts_i(int view_idx) const;
+    std::vector<std::vector<std::map<std::string, double> > >
+        get_column_component_suffstats_i(int view_idx) const;
+    std::vector<CM_Hypers> get_column_hypers() const;
+    std::map<std::string, double> get_column_partition_hypers() const;
+    std::vector<int> get_column_partition_assignments() const;
+    std::vector<int> get_column_partition_counts() const;
+    std::map<int, std::set<int> > get_column_dependencies() const;
+    std::map<int, std::set<int> > get_column_independencies() const;
+    std::vector<std::vector<int> > get_X_D() const;
+    std::vector<double> get_draw(int row_idx, int random_seed) const;
+    std::map<int, std::vector<int> > get_column_groups() const;
+    double transition_view_i(int which_view, const MatrixD& data);
+    double transition_views(const MatrixD& data);
+    double transition_row_partition_assignments(const MatrixD& data,
+                                                std::vector<int> which_rows);
+    double transition_views_zs(const MatrixD& data);
+    double transition_views_row_partition_hyper();
+    double transition_row_partition_hyperparameters(const std::vector<int>& which_cols);
+    double transition_column_hyperparameters(std::vector<int> which_cols);
+    double transition_views_col_hypers();
+    double calc_row_predictive_logp(const std::vector<double>& in_vd);
+    double transition_column_crp_alpha();
+    double transition(const MatrixD& data);
+    double draw_rand_u();
+    double draw_rand_i();
+    std::string to_string(const std::string& join_str = "\n",
+                          bool top_level = false) const;
+ private:
+    State *state;
+};
+
+#endif  // GUARD_stateNoGIL_h

--- a/cpp_code/src/StateNoGIL.cpp
+++ b/cpp_code/src/StateNoGIL.cpp
@@ -2,20 +2,26 @@
 
 using namespace std;
 
-////////////////////////////////////////////////////////////////////////
-// GIL/thread logic
-
-static void StateNoGIL::start_thread() {
-    if release_GIL {
-            Py_BEGIN_ALLOW_THREADS;
+// RAII-style GIL release. Release and acquisition logic taken from the
+// Py_{BEGIN,END}_ALLOW_THREADS macros:
+// https://github.com/python/cpython/blob/ee9c03765/Include/ceval.h#L187
+class ReleaseGIL {
+public:
+    ReleaseGIL(bool release_GIL) {
+        _release_GIL = release_GIL;
+        if (_release_GIL) {
+            _save = PyEval_SaveThread();
         }
-}
-
-static void StateNoGIL::end_thread() {
-    if release_GIL {
-            Py_END_ALLOW_THREADS;
+    };
+    ~ReleaseGIL() {
+        if (_release_GIL) {
+            PyEval_RestoreThread(_save);
         }
-}
+    };
+private:
+    bool _release_GIL;
+    PyThreadState *_save;
+};
 
 ////////////////////////////////////////////////////////////////////////
 // Method wraps
@@ -37,7 +43,7 @@ StateNoGIL::StateNoGIL(const MatrixD& data,
            const std::vector<double>& S_GRID,
            const std::vector<double>& MU_GRID,
            int N_GRID, int SEED, int CT_KERNEL) {
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     state = new State::State(data,
                              GLOBAL_COL_DATATYPES, GLOBAL_COL_MULTINOMIAL_COUNTS,
                              global_row_indices, global_col_indices, HYPERS_M,
@@ -45,7 +51,6 @@ StateNoGIL::StateNoGIL(const MatrixD& data,
                              COLUMN_CRP_ALPHA, row_partition_v, row_crp_alpha_v,
                              ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
                              S_GRID, MU_GRID, N_GRID, SEED, CT_KERNEL);
-    end_thread();
 }
 
 StateNoGIL::StateNoGIL(const MatrixD& data,
@@ -60,14 +65,13 @@ StateNoGIL::StateNoGIL(const MatrixD& data,
            const std::vector<double>& S_GRID,
            const std::vector<double>& MU_GRID,
            int N_GRID, int SEED, int CT_KERNEL) {
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     state = new State::State(data, GLOBAL_COL_DATATYPES,
                              GLOBAL_COL_MULTINOMIAL_COUNTS, global_row_indices,
                              global_col_indices, col_initialization,
                              row_initialization, ROW_CRP_ALPHA_GRID,
                              COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,
                              SEED, CT_KERNEL);
-    end_thread();
 }
 
 StateNoGIL::~StateNoGIL() {
@@ -82,9 +86,8 @@ double StateNoGIL::insert_row(const vector<double>& row_data,
                               int matching_row_idx,
                               int row_idx) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->insert_row(row_data, matching_row_idx, row_idx);
-    end_thread();
     return rv;
 }
 
@@ -99,43 +102,38 @@ double StateNoGIL::get_column_crp_score() const {
 double StateNoGIL::transition_features(const MatrixD &data,
                                   vector<int> which_features) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_features(data, which_features);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::get_data_score() const {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_data_score();
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::get_marginal_logp() const {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_marginal_logp();
-    end_thread();
     return rv;
 }
 
 map<string, double>
     StateNoGIL::get_row_partition_model_hypers_i(int view_idx) const {
     map<string, double> rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_row_partition_model_hypers_i(view_idx);
-    end_thread();
     return rv;
 }
 
 vector<int>
     StateNoGIL::get_row_partition_model_counts_i(int view_idx) const {
     vector<int> rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_row_partition_model_counts_i(view_idx);
-    end_thread();
     return rv;
 }
 
@@ -143,41 +141,36 @@ vector<vector<map<string, double> > >
     StateNoGIL::get_column_component_suffstats_i(
     int view_idx) const {
     vector<vector<map<string, double> > > rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_column_component_suffstats_i(view_idx);
-    end_thread();
     return rv;
 }
 
 vector<CM_Hypers> StateNoGIL::get_column_hypers() const {
     vector<CM_Hypers> rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_column_hypers();
-    end_thread();
     return rv;
 }
 
 map<string, double> StateNoGIL::get_column_partition_hypers() const {
     map<string, double> rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_column_partition_hypers();
-    end_thread();
     return rv;
 }
 
 vector<int> StateNoGIL::get_column_partition_assignments() const {
     vector<int> rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_column_partition_assignments();
-    end_thread();
     return rv;
 }
 
 vector<int> StateNoGIL::get_column_partition_counts() const {
     vector<int> rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_column_partition_counts();
-    end_thread();
     return rv;
 }
 
@@ -191,131 +184,115 @@ std::map<int, std::set<int> > StateNoGIL::get_column_independencies() const {
 
 vector<vector<int> > StateNoGIL::get_X_D() const {
     vector<vector<int> > rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_X_D();
-    end_thread();
     return rv;
 }
 
 vector<double> StateNoGIL::get_draw(int row_idx, int random_seed) const {
     vector<double> rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_draw(row_idx, random_seed);
-    end_thread();
     return rv;
 }
 
 map<int, vector<int> > StateNoGIL::get_column_groups() const {
     map<int, vector<int> > rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->get_column_groups();
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_view_i(int which_view, const MatrixD& data) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_view_i(which_view, data);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views(const MatrixD& data) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_views(data);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_row_partition_assignments(const MatrixD& data,
                                                    vector<int> which_rows) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_row_partition_assignments(data, which_rows);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views_zs(const MatrixD& data) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_views_zs(data);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views_row_partition_hyper() {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_views_row_partition_hyper();
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_row_partition_hyperparameters(const vector<int>&
                                                        which_cols) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_row_partition_hyperparameters(which_cols);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_column_hyperparameters(vector<int> which_cols) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_column_hyperparameters(which_cols);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views_col_hypers() {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_views_col_hypers();
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::calc_row_predictive_logp(const vector<double>& in_vd) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->calc_row_predictive_logp(in_vd);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_column_crp_alpha() {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition_column_crp_alpha();
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition(const MatrixD& data) {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->transition(data);
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::draw_rand_u() {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->draw_rand_u();
-    end_thread();
     return rv;
 }
 
 double StateNoGIL::draw_rand_i() {
     double rv;
-    start_thread();
+    ReleaseGIL _r = ReleaseGIL(release_GIL);
     rv = state->draw_rand_i();
-    end_thread();
     return rv;
 }
 

--- a/cpp_code/src/StateNoGIL.cpp
+++ b/cpp_code/src/StateNoGIL.cpp
@@ -1,0 +1,306 @@
+#include "StateNoGIL.h"
+
+using namespace std;
+
+StateNoGIL::StateNoGIL(const MatrixD& data,
+           const std::vector<std::string>& GLOBAL_COL_DATATYPES,
+           const std::vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
+           const std::vector<int>& global_row_indices,
+           const std::vector<int>& global_col_indices,
+           const std::map<int, CM_Hypers>& HYPERS_M,
+           const std::vector<std::vector<int> >& column_partition,
+           const std::map<int, std::set<int> >& col_ensure_dep,
+           const std::map<int, std::set<int> >& col_ensure_ind,
+           double COLUMN_CRP_ALPHA,
+           const std::vector<std::vector<std::vector<int> > >& row_partition_v,
+           const std::vector<double>& row_crp_alpha_v,
+           const std::vector<double>& ROW_CRP_ALPHA_GRID,
+           const std::vector<double>& COLUMN_CRP_ALPHA_GRID,
+           const std::vector<double>& S_GRID,
+           const std::vector<double>& MU_GRID,
+           int N_GRID, int SEED, int CT_KERNEL) {
+    Py_BEGIN_ALLOW_THREADS
+    state = new State::State(data,
+                             GLOBAL_COL_DATATYPES, GLOBAL_COL_MULTINOMIAL_COUNTS,
+                             global_row_indices, global_col_indices, HYPERS_M,
+                             column_partition ,col_ensure_dep, col_ensure_ind,
+                             COLUMN_CRP_ALPHA, row_partition_v, row_crp_alpha_v,
+                             ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
+                             S_GRID, MU_GRID, N_GRID, SEED, CT_KERNEL);
+    Py_END_ALLOW_THREADS
+}
+
+StateNoGIL::StateNoGIL(const MatrixD& data,
+           const std::vector<std::string>& GLOBAL_COL_DATATYPES,
+           const std::vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
+           const std::vector<int>& global_row_indices,
+           const std::vector<int>& global_col_indices,
+           const std::string& col_initialization,
+           std::string row_initialization,
+           const std::vector<double>& ROW_CRP_ALPHA_GRID,
+           const std::vector<double>& COLUMN_CRP_ALPHA_GRID,
+           const std::vector<double>& S_GRID,
+           const std::vector<double>& MU_GRID,
+           int N_GRID, int SEED, int CT_KERNEL) {
+    Py_BEGIN_ALLOW_THREADS
+    state = new State::State(data, GLOBAL_COL_DATATYPES,
+                             GLOBAL_COL_MULTINOMIAL_COUNTS, global_row_indices,
+                             global_col_indices, col_initialization,
+                             row_initialization, ROW_CRP_ALPHA_GRID,
+                             COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,
+                             SEED, CT_KERNEL);
+    Py_END_ALLOW_THREADS
+}
+
+StateNoGIL::~StateNoGIL() {
+    delete state;
+}
+
+int StateNoGIL::get_num_views() const {
+    return state->get_num_views();
+}
+
+double StateNoGIL::insert_row(const vector<double>& row_data,
+                              int matching_row_idx,
+                              int row_idx) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->insert_row(row_data, matching_row_idx, row_idx);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::get_column_crp_alpha() const {
+    return state->get_column_crp_alpha();
+}
+
+double StateNoGIL::get_column_crp_score() const {
+    return state->get_column_crp_score();
+}
+
+double StateNoGIL::transition_features(const MatrixD &data,
+                                  vector<int> which_features) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_features(data, which_features);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::get_data_score() const {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_data_score();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::get_marginal_logp() const {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_marginal_logp();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+map<string, double>
+    StateNoGIL::get_row_partition_model_hypers_i(int view_idx) const {
+    map<string, double> rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_row_partition_model_hypers_i(view_idx);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+vector<int>
+    StateNoGIL::get_row_partition_model_counts_i(int view_idx) const {
+    vector<int> rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_row_partition_model_counts_i(view_idx);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+vector<vector<map<string, double> > >
+    StateNoGIL::get_column_component_suffstats_i(
+    int view_idx) const {
+    vector<vector<map<string, double> > > rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_column_component_suffstats_i(view_idx);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+vector<CM_Hypers> StateNoGIL::get_column_hypers() const {
+    vector<CM_Hypers> rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_column_hypers();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+map<string, double> StateNoGIL::get_column_partition_hypers() const {
+    map<string, double> rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_column_partition_hypers();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+vector<int> StateNoGIL::get_column_partition_assignments() const {
+    vector<int> rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_column_partition_assignments();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+vector<int> StateNoGIL::get_column_partition_counts() const {
+    vector<int> rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_column_partition_counts();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+std::map<int, std::set<int> > StateNoGIL::get_column_dependencies() const {
+    return state->get_column_dependencies();
+}
+
+std::map<int, std::set<int> > StateNoGIL::get_column_independencies() const {
+    return state->get_column_independencies();
+}
+
+vector<vector<int> > StateNoGIL::get_X_D() const {
+    vector<vector<int> > rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_X_D();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+vector<double> StateNoGIL::get_draw(int row_idx, int random_seed) const {
+    vector<double> rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_draw(row_idx, random_seed);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+map<int, vector<int> > StateNoGIL::get_column_groups() const {
+    map<int, vector<int> > rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->get_column_groups();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_view_i(int which_view, const MatrixD& data) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_view_i(which_view, data);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_views(const MatrixD& data) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_views(data);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_row_partition_assignments(const MatrixD& data,
+                                                   vector<int> which_rows) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_row_partition_assignments(data, which_rows);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_views_zs(const MatrixD& data) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_views_zs(data);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_views_row_partition_hyper() {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_views_row_partition_hyper();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_row_partition_hyperparameters(const vector<int>&
+                                                       which_cols) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_row_partition_hyperparameters(which_cols);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_column_hyperparameters(vector<int> which_cols) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_column_hyperparameters(which_cols);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_views_col_hypers() {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_views_col_hypers();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::calc_row_predictive_logp(const vector<double>& in_vd) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->calc_row_predictive_logp(in_vd);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition_column_crp_alpha() {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition_column_crp_alpha();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::transition(const MatrixD& data) {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->transition(data);
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::draw_rand_u() {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->draw_rand_u();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+double StateNoGIL::draw_rand_i() {
+    double rv;
+    Py_BEGIN_ALLOW_THREADS
+    rv = state->draw_rand_i();
+    Py_END_ALLOW_THREADS
+    return rv;
+}
+
+string StateNoGIL::to_string(const string& join_str, bool top_level) const {
+    return state->to_string(join_str, top_level);
+}

--- a/cpp_code/src/StateNoGIL.cpp
+++ b/cpp_code/src/StateNoGIL.cpp
@@ -2,6 +2,24 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////
+// GIL/thread logic
+
+static void StateNoGIL::start_thread() {
+    if release_GIL {
+            Py_BEGIN_ALLOW_THREADS;
+        }
+}
+
+static void StateNoGIL::end_thread() {
+    if release_GIL {
+            Py_END_ALLOW_THREADS;
+        }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Method wraps
+
 StateNoGIL::StateNoGIL(const MatrixD& data,
            const std::vector<std::string>& GLOBAL_COL_DATATYPES,
            const std::vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
@@ -19,7 +37,7 @@ StateNoGIL::StateNoGIL(const MatrixD& data,
            const std::vector<double>& S_GRID,
            const std::vector<double>& MU_GRID,
            int N_GRID, int SEED, int CT_KERNEL) {
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     state = new State::State(data,
                              GLOBAL_COL_DATATYPES, GLOBAL_COL_MULTINOMIAL_COUNTS,
                              global_row_indices, global_col_indices, HYPERS_M,
@@ -27,7 +45,7 @@ StateNoGIL::StateNoGIL(const MatrixD& data,
                              COLUMN_CRP_ALPHA, row_partition_v, row_crp_alpha_v,
                              ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
                              S_GRID, MU_GRID, N_GRID, SEED, CT_KERNEL);
-    Py_END_ALLOW_THREADS
+    end_thread();
 }
 
 StateNoGIL::StateNoGIL(const MatrixD& data,
@@ -42,14 +60,14 @@ StateNoGIL::StateNoGIL(const MatrixD& data,
            const std::vector<double>& S_GRID,
            const std::vector<double>& MU_GRID,
            int N_GRID, int SEED, int CT_KERNEL) {
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     state = new State::State(data, GLOBAL_COL_DATATYPES,
                              GLOBAL_COL_MULTINOMIAL_COUNTS, global_row_indices,
                              global_col_indices, col_initialization,
                              row_initialization, ROW_CRP_ALPHA_GRID,
                              COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,
                              SEED, CT_KERNEL);
-    Py_END_ALLOW_THREADS
+    end_thread();
 }
 
 StateNoGIL::~StateNoGIL() {
@@ -64,9 +82,9 @@ double StateNoGIL::insert_row(const vector<double>& row_data,
                               int matching_row_idx,
                               int row_idx) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->insert_row(row_data, matching_row_idx, row_idx);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
@@ -81,43 +99,43 @@ double StateNoGIL::get_column_crp_score() const {
 double StateNoGIL::transition_features(const MatrixD &data,
                                   vector<int> which_features) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_features(data, which_features);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::get_data_score() const {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_data_score();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::get_marginal_logp() const {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_marginal_logp();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 map<string, double>
     StateNoGIL::get_row_partition_model_hypers_i(int view_idx) const {
     map<string, double> rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_row_partition_model_hypers_i(view_idx);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 vector<int>
     StateNoGIL::get_row_partition_model_counts_i(int view_idx) const {
     vector<int> rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_row_partition_model_counts_i(view_idx);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
@@ -125,41 +143,41 @@ vector<vector<map<string, double> > >
     StateNoGIL::get_column_component_suffstats_i(
     int view_idx) const {
     vector<vector<map<string, double> > > rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_column_component_suffstats_i(view_idx);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 vector<CM_Hypers> StateNoGIL::get_column_hypers() const {
     vector<CM_Hypers> rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_column_hypers();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 map<string, double> StateNoGIL::get_column_partition_hypers() const {
     map<string, double> rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_column_partition_hypers();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 vector<int> StateNoGIL::get_column_partition_assignments() const {
     vector<int> rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_column_partition_assignments();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 vector<int> StateNoGIL::get_column_partition_counts() const {
     vector<int> rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_column_partition_counts();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
@@ -173,131 +191,131 @@ std::map<int, std::set<int> > StateNoGIL::get_column_independencies() const {
 
 vector<vector<int> > StateNoGIL::get_X_D() const {
     vector<vector<int> > rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_X_D();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 vector<double> StateNoGIL::get_draw(int row_idx, int random_seed) const {
     vector<double> rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_draw(row_idx, random_seed);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 map<int, vector<int> > StateNoGIL::get_column_groups() const {
     map<int, vector<int> > rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->get_column_groups();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_view_i(int which_view, const MatrixD& data) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_view_i(which_view, data);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views(const MatrixD& data) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_views(data);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_row_partition_assignments(const MatrixD& data,
                                                    vector<int> which_rows) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_row_partition_assignments(data, which_rows);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views_zs(const MatrixD& data) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_views_zs(data);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views_row_partition_hyper() {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_views_row_partition_hyper();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_row_partition_hyperparameters(const vector<int>&
                                                        which_cols) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_row_partition_hyperparameters(which_cols);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_column_hyperparameters(vector<int> which_cols) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_column_hyperparameters(which_cols);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_views_col_hypers() {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_views_col_hypers();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::calc_row_predictive_logp(const vector<double>& in_vd) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->calc_row_predictive_logp(in_vd);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition_column_crp_alpha() {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition_column_crp_alpha();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::transition(const MatrixD& data) {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->transition(data);
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::draw_rand_u() {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->draw_rand_u();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 
 double StateNoGIL::draw_rand_i() {
     double rv;
-    Py_BEGIN_ALLOW_THREADS
+    start_thread();
     rv = state->draw_rand_i();
-    Py_END_ALLOW_THREADS
+    end_thread();
     return rv;
 }
 

--- a/cpp_code/src/StateNoGIL.cpp
+++ b/cpp_code/src/StateNoGIL.cpp
@@ -85,10 +85,8 @@ int StateNoGIL::get_num_views() const {
 double StateNoGIL::insert_row(const vector<double>& row_data,
                               int matching_row_idx,
                               int row_idx) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->insert_row(row_data, matching_row_idx, row_idx);
-    return rv;
+    return state->insert_row(row_data, matching_row_idx, row_idx);
 }
 
 double StateNoGIL::get_column_crp_alpha() const {
@@ -100,78 +98,57 @@ double StateNoGIL::get_column_crp_score() const {
 }
 
 double StateNoGIL::transition_features(const MatrixD &data,
-                                  vector<int> which_features) {
-    double rv;
+                                       vector<int> which_features) {
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_features(data, which_features);
-    return rv;
+    return state->transition_features(data, which_features);
 }
 
 double StateNoGIL::get_data_score() const {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_data_score();
-    return rv;
+    return state->get_data_score();
 }
 
 double StateNoGIL::get_marginal_logp() const {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_marginal_logp();
-    return rv;
+    return state->get_marginal_logp();
 }
 
 map<string, double>
     StateNoGIL::get_row_partition_model_hypers_i(int view_idx) const {
-    map<string, double> rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_row_partition_model_hypers_i(view_idx);
-    return rv;
+    return state->get_row_partition_model_hypers_i(view_idx);
 }
 
 vector<int>
     StateNoGIL::get_row_partition_model_counts_i(int view_idx) const {
-    vector<int> rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_row_partition_model_counts_i(view_idx);
-    return rv;
+    return state->get_row_partition_model_counts_i(view_idx);
 }
 
 vector<vector<map<string, double> > >
-    StateNoGIL::get_column_component_suffstats_i(
-    int view_idx) const {
-    vector<vector<map<string, double> > > rv;
+    StateNoGIL::get_column_component_suffstats_i(int view_idx) const {
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_column_component_suffstats_i(view_idx);
-    return rv;
+    return state->get_column_component_suffstats_i(view_idx);
 }
 
 vector<CM_Hypers> StateNoGIL::get_column_hypers() const {
-    vector<CM_Hypers> rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_column_hypers();
-    return rv;
+    return state->get_column_hypers();
 }
 
 map<string, double> StateNoGIL::get_column_partition_hypers() const {
-    map<string, double> rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_column_partition_hypers();
-    return rv;
+    return state->get_column_partition_hypers();
 }
 
 vector<int> StateNoGIL::get_column_partition_assignments() const {
-    vector<int> rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_column_partition_assignments();
-    return rv;
+    return state->get_column_partition_assignments();
 }
 
 vector<int> StateNoGIL::get_column_partition_counts() const {
-    vector<int> rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_column_partition_counts();
-    return rv;
+    return state->get_column_partition_counts();
 }
 
 std::map<int, std::set<int> > StateNoGIL::get_column_dependencies() const {
@@ -183,117 +160,85 @@ std::map<int, std::set<int> > StateNoGIL::get_column_independencies() const {
 }
 
 vector<vector<int> > StateNoGIL::get_X_D() const {
-    vector<vector<int> > rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_X_D();
-    return rv;
+    return state->get_X_D();
 }
 
 vector<double> StateNoGIL::get_draw(int row_idx, int random_seed) const {
-    vector<double> rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_draw(row_idx, random_seed);
-    return rv;
+    return state->get_draw(row_idx, random_seed);
 }
 
 map<int, vector<int> > StateNoGIL::get_column_groups() const {
-    map<int, vector<int> > rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->get_column_groups();
-    return rv;
+    return state->get_column_groups();
 }
 
 double StateNoGIL::transition_view_i(int which_view, const MatrixD& data) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_view_i(which_view, data);
-    return rv;
+    return state->transition_view_i(which_view, data);
 }
 
 double StateNoGIL::transition_views(const MatrixD& data) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_views(data);
-    return rv;
+    return state->transition_views(data);
 }
 
 double StateNoGIL::transition_row_partition_assignments(const MatrixD& data,
                                                    vector<int> which_rows) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_row_partition_assignments(data, which_rows);
-    return rv;
+    return state->transition_row_partition_assignments(data, which_rows);
 }
 
 double StateNoGIL::transition_views_zs(const MatrixD& data) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_views_zs(data);
-    return rv;
+    return state->transition_views_zs(data);
 }
 
 double StateNoGIL::transition_views_row_partition_hyper() {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_views_row_partition_hyper();
-    return rv;
+    return state->transition_views_row_partition_hyper();
 }
 
 double StateNoGIL::transition_row_partition_hyperparameters(const vector<int>&
                                                        which_cols) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_row_partition_hyperparameters(which_cols);
-    return rv;
+    return state->transition_row_partition_hyperparameters(which_cols);
 }
 
 double StateNoGIL::transition_column_hyperparameters(vector<int> which_cols) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_column_hyperparameters(which_cols);
-    return rv;
+    return state->transition_column_hyperparameters(which_cols);
 }
 
 double StateNoGIL::transition_views_col_hypers() {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_views_col_hypers();
-    return rv;
+    return state->transition_views_col_hypers();
 }
 
 double StateNoGIL::calc_row_predictive_logp(const vector<double>& in_vd) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->calc_row_predictive_logp(in_vd);
-    return rv;
+    return state->calc_row_predictive_logp(in_vd);
 }
 
 double StateNoGIL::transition_column_crp_alpha() {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition_column_crp_alpha();
-    return rv;
+    return state->transition_column_crp_alpha();
 }
 
 double StateNoGIL::transition(const MatrixD& data) {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->transition(data);
-    return rv;
+    return state->transition(data);
 }
 
 double StateNoGIL::draw_rand_u() {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->draw_rand_u();
-    return rv;
+    return state->draw_rand_u();
 }
 
 double StateNoGIL::draw_rand_i() {
-    double rv;
     ReleaseGIL _r = ReleaseGIL(release_GIL);
-    rv = state->draw_rand_i();
-    return rv;
+    return state->draw_rand_i();
 }
 
 string StateNoGIL::to_string(const string& join_str, bool top_level) const {

--- a/cpp_code/src/StateNoGIL.cpp
+++ b/cpp_code/src/StateNoGIL.cpp
@@ -2,13 +2,16 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////
+// GIL-handling logic
+
 // RAII-style GIL release. Release and acquisition logic taken from the
 // Py_{BEGIN,END}_ALLOW_THREADS macros:
 // https://github.com/python/cpython/blob/ee9c03765/Include/ceval.h#L187
 class ReleaseGIL {
 public:
-    ReleaseGIL(bool release_GIL) {
-        _release_GIL = release_GIL;
+    ReleaseGIL() {
+        _release_GIL = StateNoGIL::release_GIL;
         if (_release_GIL) {
             _save = PyEval_SaveThread();
         }
@@ -23,27 +26,30 @@ private:
     PyThreadState *_save;
 };
 
+// Default to releasing GIL on crosscat calls
+bool StateNoGIL::release_GIL = true;
+
 ////////////////////////////////////////////////////////////////////////
 // Method wraps
 
 StateNoGIL::StateNoGIL(const MatrixD& data,
-           const std::vector<std::string>& GLOBAL_COL_DATATYPES,
-           const std::vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
-           const std::vector<int>& global_row_indices,
-           const std::vector<int>& global_col_indices,
-           const std::map<int, CM_Hypers>& HYPERS_M,
-           const std::vector<std::vector<int> >& column_partition,
-           const std::map<int, std::set<int> >& col_ensure_dep,
-           const std::map<int, std::set<int> >& col_ensure_ind,
+           const vector<string>& GLOBAL_COL_DATATYPES,
+           const vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
+           const vector<int>& global_row_indices,
+           const vector<int>& global_col_indices,
+           const map<int, CM_Hypers>& HYPERS_M,
+           const vector<vector<int> >& column_partition,
+           const map<int, set<int> >& col_ensure_dep,
+           const map<int, set<int> >& col_ensure_ind,
            double COLUMN_CRP_ALPHA,
-           const std::vector<std::vector<std::vector<int> > >& row_partition_v,
-           const std::vector<double>& row_crp_alpha_v,
-           const std::vector<double>& ROW_CRP_ALPHA_GRID,
-           const std::vector<double>& COLUMN_CRP_ALPHA_GRID,
-           const std::vector<double>& S_GRID,
-           const std::vector<double>& MU_GRID,
+           const vector<vector<vector<int> > >& row_partition_v,
+           const vector<double>& row_crp_alpha_v,
+           const vector<double>& ROW_CRP_ALPHA_GRID,
+           const vector<double>& COLUMN_CRP_ALPHA_GRID,
+           const vector<double>& S_GRID,
+           const vector<double>& MU_GRID,
            int N_GRID, int SEED, int CT_KERNEL) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     state = new State::State(data,
                              GLOBAL_COL_DATATYPES, GLOBAL_COL_MULTINOMIAL_COUNTS,
                              global_row_indices, global_col_indices, HYPERS_M,
@@ -54,18 +60,18 @@ StateNoGIL::StateNoGIL(const MatrixD& data,
 }
 
 StateNoGIL::StateNoGIL(const MatrixD& data,
-           const std::vector<std::string>& GLOBAL_COL_DATATYPES,
-           const std::vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
-           const std::vector<int>& global_row_indices,
-           const std::vector<int>& global_col_indices,
-           const std::string& col_initialization,
-           std::string row_initialization,
-           const std::vector<double>& ROW_CRP_ALPHA_GRID,
-           const std::vector<double>& COLUMN_CRP_ALPHA_GRID,
-           const std::vector<double>& S_GRID,
-           const std::vector<double>& MU_GRID,
+           const vector<string>& GLOBAL_COL_DATATYPES,
+           const vector<int>& GLOBAL_COL_MULTINOMIAL_COUNTS,
+           const vector<int>& global_row_indices,
+           const vector<int>& global_col_indices,
+           const string& col_initialization,
+           string row_initialization,
+           const vector<double>& ROW_CRP_ALPHA_GRID,
+           const vector<double>& COLUMN_CRP_ALPHA_GRID,
+           const vector<double>& S_GRID,
+           const vector<double>& MU_GRID,
            int N_GRID, int SEED, int CT_KERNEL) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     state = new State::State(data, GLOBAL_COL_DATATYPES,
                              GLOBAL_COL_MULTINOMIAL_COUNTS, global_row_indices,
                              global_col_indices, col_initialization,
@@ -85,7 +91,7 @@ int StateNoGIL::get_num_views() const {
 double StateNoGIL::insert_row(const vector<double>& row_data,
                               int matching_row_idx,
                               int row_idx) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->insert_row(row_data, matching_row_idx, row_idx);
 }
 
@@ -99,145 +105,145 @@ double StateNoGIL::get_column_crp_score() const {
 
 double StateNoGIL::transition_features(const MatrixD &data,
                                        vector<int> which_features) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_features(data, which_features);
 }
 
 double StateNoGIL::get_data_score() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_data_score();
 }
 
 double StateNoGIL::get_marginal_logp() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_marginal_logp();
 }
 
 map<string, double>
     StateNoGIL::get_row_partition_model_hypers_i(int view_idx) const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_row_partition_model_hypers_i(view_idx);
 }
 
 vector<int>
     StateNoGIL::get_row_partition_model_counts_i(int view_idx) const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_row_partition_model_counts_i(view_idx);
 }
 
 vector<vector<map<string, double> > >
     StateNoGIL::get_column_component_suffstats_i(int view_idx) const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_column_component_suffstats_i(view_idx);
 }
 
 vector<CM_Hypers> StateNoGIL::get_column_hypers() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_column_hypers();
 }
 
 map<string, double> StateNoGIL::get_column_partition_hypers() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_column_partition_hypers();
 }
 
 vector<int> StateNoGIL::get_column_partition_assignments() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_column_partition_assignments();
 }
 
 vector<int> StateNoGIL::get_column_partition_counts() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_column_partition_counts();
 }
 
-std::map<int, std::set<int> > StateNoGIL::get_column_dependencies() const {
+map<int, set<int> > StateNoGIL::get_column_dependencies() const {
     return state->get_column_dependencies();
 }
 
-std::map<int, std::set<int> > StateNoGIL::get_column_independencies() const {
+map<int, set<int> > StateNoGIL::get_column_independencies() const {
     return state->get_column_independencies();
 }
 
 vector<vector<int> > StateNoGIL::get_X_D() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_X_D();
 }
 
 vector<double> StateNoGIL::get_draw(int row_idx, int random_seed) const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_draw(row_idx, random_seed);
 }
 
 map<int, vector<int> > StateNoGIL::get_column_groups() const {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->get_column_groups();
 }
 
 double StateNoGIL::transition_view_i(int which_view, const MatrixD& data) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_view_i(which_view, data);
 }
 
 double StateNoGIL::transition_views(const MatrixD& data) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_views(data);
 }
 
 double StateNoGIL::transition_row_partition_assignments(const MatrixD& data,
                                                    vector<int> which_rows) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_row_partition_assignments(data, which_rows);
 }
 
 double StateNoGIL::transition_views_zs(const MatrixD& data) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_views_zs(data);
 }
 
 double StateNoGIL::transition_views_row_partition_hyper() {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_views_row_partition_hyper();
 }
 
 double StateNoGIL::transition_row_partition_hyperparameters(const vector<int>&
                                                        which_cols) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_row_partition_hyperparameters(which_cols);
 }
 
 double StateNoGIL::transition_column_hyperparameters(vector<int> which_cols) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_column_hyperparameters(which_cols);
 }
 
 double StateNoGIL::transition_views_col_hypers() {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_views_col_hypers();
 }
 
 double StateNoGIL::calc_row_predictive_logp(const vector<double>& in_vd) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->calc_row_predictive_logp(in_vd);
 }
 
 double StateNoGIL::transition_column_crp_alpha() {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition_column_crp_alpha();
 }
 
 double StateNoGIL::transition(const MatrixD& data) {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->transition(data);
 }
 
 double StateNoGIL::draw_rand_u() {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->draw_rand_u();
 }
 
 double StateNoGIL::draw_rand_i() {
-    ReleaseGIL _r = ReleaseGIL(release_GIL);
+    ReleaseGIL _r = ReleaseGIL();
     return state->draw_rand_i();
 }
 

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ StateNoGIL_cpp_sources.remove('State.cpp')
 StateNoGIL_cpp_sources.append('StateNoGIL.cpp')
 StateNoGIL_sources = generate_sources([
     (pyx_src_dir, StateNoGIL_pyx_sources),
-    (cpp_src_dir, StateNoGIL_pyx_sources)
+    (cpp_src_dir, StateNoGIL_cpp_sources)
 ])
 
 
@@ -252,7 +252,7 @@ CyclicComponentModel_ext = Extension(
 
 StateNoGIL_ext = Extension(
     'crosscat.cython_code.State',
-    extra_compile_args = ["-std=c++11 "],
+    extra_compile_args = [],
     sources=StateNoGIL_sources,
     include_dirs=include_dirs,
     language='c++',

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,15 @@ State_sources = generate_sources([
     (cpp_src_dir, State_cpp_sources),
 ])
 
+StateNoGIL_pyx_sources = ['StateNoGIL.pyx']
+StateNoGIL_cpp_sources = State_cpp_sources[:]
+StateNoGIL_cpp_sources.remove('State.cpp')
+StateNoGIL_cpp_sources.append('StateNoGIL.cpp')
+StateNoGIL_sources = generate_sources([
+    (pyx_src_dir, StateNoGIL_pyx_sources),
+    (cpp_src_dir, StateNoGIL_cpp_sources),
+])
+
 
 # create exts
 ContinuousComponentModel_ext = Extension(
@@ -240,12 +249,21 @@ State_ext = Extension(
     include_dirs=include_dirs,
     language='c++',
 )
+
+StateNoGIL_ext = Extension(
+    'crosscat.cython_code.StateNoGIL',
+    extra_compile_args = [],
+    sources=StateNoGIL_sources,
+    include_dirs=include_dirs,
+    language='c++',
+)
 #
 ext_modules = [
     CyclicComponentModel_ext,
     ContinuousComponentModel_ext,
     MultinomialComponentModel_ext,
     State_ext,
+    StateNoGIL_ext
 ]
 
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ def parallelCCompile(self, sources, output_dir=None, macros=None,
     return objects
 #
 import distutils.ccompiler
-distutils.ccompiler.CCompiler.compile=parallelCCompile
+# distutils.ccompiler.CCompiler.compile=parallelCCompile
 
 def generate_sources(dir_files_tuples):
     sources = []
@@ -210,13 +210,13 @@ State_sources = generate_sources([
     (cpp_src_dir, State_cpp_sources),
 ])
 
-StateNoGIL_pyx_sources = ['StateNoGIL.pyx']
+StateNoGIL_pyx_sources = ['State.pyx']
 StateNoGIL_cpp_sources = State_cpp_sources[:]
 StateNoGIL_cpp_sources.remove('State.cpp')
 StateNoGIL_cpp_sources.append('StateNoGIL.cpp')
 StateNoGIL_sources = generate_sources([
     (pyx_src_dir, StateNoGIL_pyx_sources),
-    (cpp_src_dir, StateNoGIL_cpp_sources),
+    (cpp_src_dir, StateNoGIL_pyx_sources)
 ])
 
 
@@ -242,17 +242,17 @@ CyclicComponentModel_ext = Extension(
     include_dirs=include_dirs,
     language='c++',
 )
-State_ext = Extension(
-    'crosscat.cython_code.State',
-    extra_compile_args = [],
-    sources=State_sources,
-    include_dirs=include_dirs,
-    language='c++',
-)
+#State_ext = Extension(
+#    'crosscat.cython_code.State',
+#    extra_compile_args = [],
+#    sources=State_sources,
+#    include_dirs=include_dirs,
+#    language='c++',
+#)
 
 StateNoGIL_ext = Extension(
-    'crosscat.cython_code.StateNoGIL',
-    extra_compile_args = [],
+    'crosscat.cython_code.State',
+    extra_compile_args = ["-std=c++11 "],
     sources=StateNoGIL_sources,
     include_dirs=include_dirs,
     language='c++',
@@ -262,7 +262,7 @@ ext_modules = [
     CyclicComponentModel_ext,
     ContinuousComponentModel_ext,
     MultinomialComponentModel_ext,
-    State_ext,
+    # State_ext,
     StateNoGIL_ext
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -211,9 +211,7 @@ State_sources = generate_sources([
 ])
 
 StateNoGIL_pyx_sources = ['State.pyx']
-StateNoGIL_cpp_sources = State_cpp_sources[:]
-StateNoGIL_cpp_sources.remove('State.cpp')
-StateNoGIL_cpp_sources.append('StateNoGIL.cpp')
+StateNoGIL_cpp_sources = State_cpp_sources + ['StateNoGIL.cpp']
 StateNoGIL_sources = generate_sources([
     (pyx_src_dir, StateNoGIL_pyx_sources),
     (cpp_src_dir, StateNoGIL_cpp_sources)

--- a/src/LocalEngine.py
+++ b/src/LocalEngine.py
@@ -719,6 +719,9 @@ class LocalEngine(EngineTemplate.EngineTemplate):
             return model_assertions[0]
         pass
 
+    def set_GIL_handling(self, release):
+        "Release GIL during crosscat calculations if release is True"
+        State.set_crosscat_GIL_handling(release)
 
 def do_diagnostics_to_func_dict(do_diagnostics):
     diagnostic_func_dict = None

--- a/src/cython_code/State.pyx
+++ b/src/cython_code/State.pyx
@@ -146,6 +146,11 @@ cdef extern from "StateNoGIL.h":
                                    vector[double] MU_GRID,
                                    int N_GRID, int SEED, int CT_KERNEL)
      void del_State "delete" (StateNoGIL *s)
+     bool release_GIL
+
+
+cpdef set_crosscat_GIL_handling(bool release):
+    release_GIL = release
 
 
 def extract_column_types_counts(M_c):
@@ -561,7 +566,7 @@ def get_column_component_suffstats_by_global_col_idx(M_c, X_L, col_idx):
      within_view_idx = view_state_i['column_names'].index(col_name)
      column_component_suffstats_i = view_state_i['column_component_suffstats'][within_view_idx]
      return column_component_suffstats_i
-     
+
 def sparsify_X_L(M_c, X_L):
      for col_idx, col_i_metadata in enumerate(M_c['column_metadata']):
           modeltype = col_i_metadata['modeltype']

--- a/src/cython_code/State.pyx
+++ b/src/cython_code/State.pyx
@@ -74,8 +74,8 @@ cdef matrix[double]* convert_data_to_cpp(np.ndarray[np.float64_t, ndim=2] data):
                set_double(dereference(dataptr)(i,j), data[i,j])
      return dataptr
 
-cdef extern from "State.h":
-     cdef cppclass State:
+cdef extern from "StateNoGIL.h":
+     cdef cppclass StateNoGIL:
           # mutators
           double insert_row(vector[double] row_data, int matching_row_idx, int
                   row_idx)
@@ -116,7 +116,7 @@ cdef extern from "State.h":
           #
           vector[vector[int]] get_X_D()
           void SaveResult()
-     State *new_State "new State" (matrix[double] &data,
+     StateNoGIL *new_State "new StateNoGIL" (matrix[double] &data,
                                    vector[string] global_col_datatypes,
                                    vector[int] global_col_multinomial_counts,
                                    vector[int] global_row_indices,
@@ -128,7 +128,7 @@ cdef extern from "State.h":
                                    vector[double] S_GRID,
                                    vector[double] MU_GRID,
                                    int N_GRID, int SEED, int CT_KERNEL)
-     State *new_State "new State" (matrix[double] &data,
+     StateNoGIL *new_State "new StateNoGIL" (matrix[double] &data,
                                    vector[string] global_col_datatypes,
                                    vector[int] global_col_multinomial_counts,
                                    vector[int] global_row_indices,
@@ -145,7 +145,7 @@ cdef extern from "State.h":
                                    vector[double] S_GRID,
                                    vector[double] MU_GRID,
                                    int N_GRID, int SEED, int CT_KERNEL)
-     void del_State "delete" (State *s)
+     void del_State "delete" (StateNoGIL *s)
 
 
 def extract_column_types_counts(M_c):
@@ -181,7 +181,7 @@ def get_all_transitions_permuted(seed):
      return which_transitions
 
 cdef class p_State:
-    cdef State *thisptr
+    cdef StateNoGIL *thisptr
     cdef matrix[double] *dataptr
     cdef vector[int] gri
     cdef vector[int] gci


### PR DESCRIPTION
CrossCat wrapper to release the GIL

I don't care how grumpy a cat is, it shouldn't hold on to a thing like the GIL when it doesn't need to. I don't know how cats get away with this kind of stuff. We've been shaming dogs and each other about it for [millenia](https://en.wikipedia.org/wiki/The_Dog_in_the_Manger), but somehow when a cat does it it's supposed to be cute.

Options I considered:

- Releasing the gil in cython code, with `with nogil:`. This is cumbersome, because automatic translation between python and C++ `std` library data structures cannot take place in `with nogil:` blocks, so you have to litter the code with intermediate placeholder variables holding the translations.

- Simply putting `Py_BEGIN_ALLOW_THREADS` and `Py_END_ALLOW_THREADS` everywhere relevant in `State.cpp`. This makes the code non-reentrant, because [you can't nest calls to these macros](https://github.com/python/cpython/blob/master/Include/ceval.h#L158), and actually breaks crosscat already because crosscat calls some of its external API internally.

- [Adapting cython with a new keyword for this situation](https://groups.google.com/forum/#!topic/cython-users/q4j_Gf6HMeU).

- This way, which uses a specialized container class to wrap calls to the State object. This isn't as clean as adapting cython, but it allows for good separation of concerns (crosscat stays pure C++), and is hygenic in that modifications to the crosscat API can't have any functional impact unless the corresponding modifications are made to the wrapper API.
