### PR TITLE
20161115 fsaad progress with diagnostics

### DIFF
--- a/src/CrossCatClient.py
+++ b/src/CrossCatClient.py
@@ -17,28 +17,20 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
 import os
 import inspect
-#
 
 
 class CrossCatClient(object):
-    """ A client interface that gives a singular interface to all the different
-    engines
+    """A client interface that gives a singue interface to the various engines.
 
-    Depending on the client_type, dispatch to the appropriate engine constructor
-
+    Depending on the client_type, dispatch to appropriate engine constructor.
     """
 
     def __init__(self, engine):
-        """Initialize client with given engine
-
-        Not to be called directly!
-
-        """
-
+        """Initialize client with given engine. Not to be called directly!"""
         self.engine = engine
-        return
 
     def __getattribute__(self, name):
         engine = object.__getattribute__(self, 'engine')
@@ -49,48 +41,23 @@ class CrossCatClient(object):
             attr = object.__getattribute__(self, name)
         return attr
 
+
 # Maybe this should be in CrossCatClient.__init__
 def get_CrossCatClient(client_type, **kwargs):
-    """Helper which instantiates the appropriate Engine and returns a Client
-
-    """
-
+    """Helper which instantiates the appropriate Engine and returns a Client"""
     client = None
+
     if client_type == 'local':
         import crosscat.LocalEngine as LocalEngine
         le = LocalEngine.LocalEngine(**kwargs)
         client = CrossCatClient(le)
+
     elif client_type == 'multiprocessing':
         import crosscat.MultiprocessingEngine as MultiprocessingEngine
         me =  MultiprocessingEngine.MultiprocessingEngine(**kwargs)
         client = CrossCatClient(me)
+
     else:
         raise Exception('unknown client_type: %s' % client_type)
+
     return client
-
-
-if __name__ == '__main__':
-    import crosscat.utils.data_utils as du
-    import random
-    ccc = get_CrossCatClient('local', seed=0)
-    #
-    gen_seed = 0
-    num_clusters = 4
-    num_cols = 8
-    num_rows = 16
-    num_splits = 1
-    max_mean = 10
-    max_std = 0.1
-    rng = random.Random(gen_seed)
-    get_next_seed = lambda: rng.randint(1, 2**31 - 1)
-    T, M_r, M_c = du.gen_factorial_data_objects(
-        get_next_seed(), num_clusters,
-        num_cols, num_rows, num_splits,
-        max_mean=max_mean, max_std=max_std,
-        )
-    #
-    X_L, X_D, = ccc.initialize(M_c, M_r, T, get_next_seed())
-    X_L_prime, X_D_prime = ccc.analyze(M_c, T, X_L, X_D, get_next_seed())
-    X_L_prime, X_D_prime = ccc.analyze(M_c, T, X_L_prime, X_D_prime,
-        get_next_seed())
-    #

--- a/src/EngineTemplate.py
+++ b/src/EngineTemplate.py
@@ -17,6 +17,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
 import crosscat.utils.general_utils as gu
 
 
@@ -29,14 +30,11 @@ class EngineTemplate(object):
         M_c, M_r, X_L, X_D = dict(), dict(), dict(), []
         return X_L, X_D
 
-    def analyze(self, M_c, T, X_L, X_D, seed, kernel_list=(), n_steps=1, c=(),
-                r=(),
-                max_iterations=-1, max_time=-1, do_diagnostics=False,
-                diagnostics_every_N=1,
-                ROW_CRP_ALPHA_GRID=(), COLUMN_CRP_ALPHA_GRID=(),
-                S_GRID=(), MU_GRID=(),
-                N_GRID=31,
-                ):
+    def analyze(
+            self, M_c, T, X_L, X_D, seed, kernel_list=(), n_steps=1, c=(),
+            r=(), max_iterations=-1, max_time=-1, do_diagnostics=False,
+            diagnostics_every_N=1, ROW_CRP_ALPHA_GRID=(),
+            COLUMN_CRP_ALPHA_GRID=(), S_GRID=(), MU_GRID=(), N_GRID=31,):
         X_L_prime, X_D_prime = dict(), []
         return X_L_prime, X_D_prime
 
@@ -48,12 +46,13 @@ class EngineTemplate(object):
         p = None
         return p
 
-    def simple_predictive_probability_multistate(self, M_c, X_L_list, X_D_list, Y, Q, n):
+    def simple_predictive_probability_multistate(
+            self, M_c, X_L_list, X_D_list, Y, Q, n):
         p = None
         return p
 
-    def mutual_information(self, M_c, X_L_list, X_D_list, Q, seed,
-                           n_samples=1000):
+    def mutual_information(
+        self, M_c, X_L_list, X_D_list, Q, seed, n_samples=1000):
         return None
 
     def row_structural_typicality(self, X_L_list, X_D_list, row_id):
@@ -68,7 +67,9 @@ class EngineTemplate(object):
     def predictive_probability_multistate(self, M_c, X_L_list, X_D_list, T, Q, n=1):
         return None
 
-    def similarity(self, M_c, X_L_list, X_D_list, given_row_id, target_row_id, target_columns=None):
+    def similarity(
+            self, M_c, X_L_list, X_D_list, given_row_id, target_row_id,
+            target_columns=None):
         return None
 
     def impute(self, M_c, X_L, X_D, Y, Q, seed, n):
@@ -79,13 +80,13 @@ class EngineTemplate(object):
         e, confidence = None, None
         return e, confidence
 
-    def conditional_entropy(M_c, X_L, X_D, d_given, d_target,
-                            n=None, max_time=None):
+    def conditional_entropy(
+            M_c, X_L, X_D, d_given, d_target, n=None, max_time=None):
         e = None
         return e
 
-    def predictively_related(self, M_c, X_L, X_D, d,
-                                           n=None, max_time=None):
+    def predictively_related(
+            self, M_c, X_L, X_D, d, n=None, max_time=None):
         m = []
         return m
 
@@ -108,4 +109,3 @@ class EngineTemplate(object):
     def predictive_anomalousness(self, M_c, X_L, X_D, T, q, n):
         a = []
         return a
-

--- a/src/EngineTemplate.py
+++ b/src/EngineTemplate.py
@@ -52,7 +52,7 @@ class EngineTemplate(object):
         return p
 
     def mutual_information(
-        self, M_c, X_L_list, X_D_list, Q, seed, n_samples=1000):
+            self, M_c, X_L_list, X_D_list, Q, seed, n_samples=1000):
         return None
 
     def row_structural_typicality(self, X_L_list, X_D_list, row_id):
@@ -64,7 +64,8 @@ class EngineTemplate(object):
     def predictive_probability(self, M_c, X_L, X_D, T, Q, n=1):
         return None
 
-    def predictive_probability_multistate(self, M_c, X_L_list, X_D_list, T, Q, n=1):
+    def predictive_probability_multistate(
+            self, M_c, X_L_list, X_D_list, T, Q, n=1):
         return None
 
     def similarity(

--- a/src/EngineTemplate.py
+++ b/src/EngineTemplate.py
@@ -81,7 +81,7 @@ class EngineTemplate(object):
         return e, confidence
 
     def conditional_entropy(
-            M_c, X_L, X_D, d_given, d_target, n=None, max_time=None):
+            self, M_c, X_L, X_D, d_given, d_target, n=None, max_time=None):
         e = None
         return e
 

--- a/src/LocalEngine.py
+++ b/src/LocalEngine.py
@@ -860,9 +860,12 @@ def _do_analyze_with_diagnostic(SEED, X_L, X_D, M_c, T, kernel_list, n_steps, c,
                             CT_KERNEL=CT_KERNEL,
                             )
     with gu.Timer('all transitions', verbose=False) as timer:
+        # XXX If doing diagnostics (i.e. invoking from bayeslite) skip the
+        # progress bar.
+        progress = len(child_n_steps_list) == 1
         for child_n_steps in child_n_steps_list:
             p_State.transition(kernel_list, child_n_steps, c, r,
-                               max_iterations, max_time)
+                               max_iterations, max_time, progress=progress)
             for diagnostic_name, diagnostic_func in six.iteritems(diagnostic_func_dict):
                 diagnostic_value = diagnostic_func(p_State)
                 diagnostics_dict[diagnostic_name].append(diagnostic_value)

--- a/src/LocalEngine.py
+++ b/src/LocalEngine.py
@@ -825,25 +825,16 @@ def _do_analyze_with_diagnostic(
         diagnostic_func_dict = dict()
         every_N = None
 
-    child_n_steps_list = get_child_n_steps_list(n_steps, every_N)
-
     p_State = State.p_State(
         M_c, T, X_L, X_D, SEED=SEED, ROW_CRP_ALPHA_GRID=ROW_CRP_ALPHA_GRID,
         COLUMN_CRP_ALPHA_GRID=COLUMN_CRP_ALPHA_GRID, S_GRID=S_GRID,
         MU_GRID=MU_GRID, N_GRID=N_GRID, CT_KERNEL=CT_KERNEL)
 
     with gu.Timer('all transitions', verbose=False) as timer:
-        # XXX If doing diagnostics (i.e. invoking from bayeslite) skip the
-        # progress bar.
-        progress = len(child_n_steps_list) == 1
-        for child_n_steps in child_n_steps_list:
-            p_State.transition(
-                kernel_list, child_n_steps, c, r, max_iterations,
-                max_time, progress=progress)
-            for diagnostic_name, diagnostic_func in\
-                    six.iteritems(diagnostic_func_dict):
-                diagnostic_value = diagnostic_func(p_State)
-                diagnostics_dict[diagnostic_name].append(diagnostic_value)
+        p_State.transition(
+            kernel_list, n_steps, c, r, max_iterations,
+            max_time, progress=True, diagnostic_func_dict=diagnostic_func_dict,
+            diagnostics_dict=diagnostics_dict, diagnostics_every_N=every_N)
 
     X_L_prime = p_State.get_X_L()
     X_D_prime = p_State.get_X_D()

--- a/src/LocalEngine.py
+++ b/src/LocalEngine.py
@@ -17,34 +17,34 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
 from __future__ import print_function
-from six.moves import range
+
+import collections
 import copy
 import itertools
-import collections
 import numpy
 import six
 
-import crosscat.cython_code.State as State
+from six.moves import range
+
 import crosscat.EngineTemplate as EngineTemplate
-import crosscat.utils.sample_utils as su
+import crosscat.cython_code.State as State
 import crosscat.utils.general_utils as gu
 import crosscat.utils.inference_utils as iu
+import crosscat.utils.sample_utils as su
 
-# for default_diagnostic_func_dict below
+# For `default_diagnostic_func_dict` below.
 import crosscat.utils.diagnostic_utils
 
 
 class LocalEngine(EngineTemplate.EngineTemplate):
+    """A simple interface to the Cython-wrapped C++ engine.
 
-    """A simple interface to the Cython-wrapped C++ engine
-
-    LocalEngine holds no state.
-    Methods use resources on the local machine.
+    LocalEngine holds no state. Methods use resources on the local machine.
     """
 
     def __init__(self, seed=None):
-        """Initialize a LocalEngine."""
         super(LocalEngine, self).__init__(seed=seed)
         self.mapper = lambda *args: list(six.moves.map(*args))
         self.do_initialize = _do_initialize_tuple
@@ -52,13 +52,11 @@ class LocalEngine(EngineTemplate.EngineTemplate):
         self.do_insert = _do_insert_tuple
         return
 
-    def get_initialize_arg_tuples(self, M_c, M_r, T, initialization,
-                                  row_initialization, n_chains,
-                                  ROW_CRP_ALPHA_GRID,
-                                  COLUMN_CRP_ALPHA_GRID,
-                                  S_GRID, MU_GRID,
-                                  N_GRID,
-                                  get_next_seed):
+
+    def get_initialize_arg_tuples(
+            self, M_c, M_r, T, initialization, row_initialization, n_chains,
+            ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,
+            get_next_seed):
         seeds = [get_next_seed() for seed_idx in range(n_chains)]
         arg_tuples = six.moves.zip(
             seeds,
@@ -75,48 +73,36 @@ class LocalEngine(EngineTemplate.EngineTemplate):
         )
         return arg_tuples
 
-    def initialize(self, M_c, M_r, T, seed, initialization=b'from_the_prior',
-                   row_initialization=-1, n_chains=1,
-                   ROW_CRP_ALPHA_GRID=(),
-                   COLUMN_CRP_ALPHA_GRID=(),
-                   S_GRID=(), MU_GRID=(),
-                   N_GRID=31,
-                   # subsample=False,
-                   # subsample_proportion=None,
-                   # subsample_rows_list=None,
-                   ):
-        """Sample a latent state from prior
 
-        :param seed: The random seed
-        :type seed: int
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param M_r: The row metadata
-        :type M_r: dict
-        :param T: The data table in mapped representation (all floats, generated
-                  by data_utils.read_data_objects)
-        :type T: list of lists
+    def initialize(
+            self, M_c, M_r, T, seed, initialization=b'from_the_prior',
+            row_initialization=-1, n_chains=1,
+            ROW_CRP_ALPHA_GRID=(), COLUMN_CRP_ALPHA_GRID=(),
+            S_GRID=(), MU_GRID=(), N_GRID=31,):
+        """Sample a latent state from prior.
+
+        T, list of lists:
+            The data table in mapped representation (all floats, generated
+            by data_utils.read_data_objects)
+
         :returns: X_L, X_D -- the latent state
-
         """
-
         # FIXME: why is M_r passed?
         arg_tuples = self.get_initialize_arg_tuples(
-            M_c, M_r, T, initialization,
-            row_initialization, n_chains,
-            ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
-            S_GRID, MU_GRID,
-            N_GRID,
-            make_get_next_seed(seed),
-        )
-        chain_tuples = self.mapper(self.do_initialize, arg_tuples)
+            M_c, M_r, T, initialization, row_initialization, n_chains,
+            ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,
+            make_get_next_seed(seed),)
 
+        chain_tuples = self.mapper(self.do_initialize, arg_tuples)
         X_L_list, X_D_list = zip(*chain_tuples)
         if n_chains == 1:
             X_L_list, X_D_list = X_L_list[0], X_D_list[0]
+
         return X_L_list, X_D_list
 
-    def get_insert_arg_tuples(self, M_c, T, X_L_list, X_D_list, new_rows, N_GRID, CT_KERNEL):
+
+    def get_insert_arg_tuples(
+            self, M_c, T, X_L_list, X_D_list, new_rows, N_GRID, CT_KERNEL):
         arg_tuples = six.moves.zip(
             itertools.cycle([M_c]),
             itertools.cycle([T]),
@@ -127,11 +113,11 @@ class LocalEngine(EngineTemplate.EngineTemplate):
         )
         return arg_tuples
 
-    def insert(self, M_c, T, X_L_list, X_D_list, new_rows=None, N_GRID=31, CT_KERNEL=0):
-        """
-        Insert mutates the data T.
-        """
 
+    def insert(
+            self, M_c, T, X_L_list, X_D_list, new_rows=None, N_GRID=31,
+            CT_KERNEL=0):
+        """Insert mutates the data T."""
         if new_rows is None:
             raise ValueError("new_row must exist")
 
@@ -140,11 +126,12 @@ class LocalEngine(EngineTemplate.EngineTemplate):
             if not isinstance(new_rows[0], list):
                 raise TypeError('new_rows must be list of lists')
 
-        X_L_list, X_D_list, was_multistate = su.ensure_multistate(X_L_list, X_D_list)
+        X_L_list, X_D_list, was_multistate = su.ensure_multistate(
+            X_L_list, X_D_list)
 
         # get insert arg tuples
-        arg_tuples = self.get_insert_arg_tuples(M_c, T, X_L_list, X_D_list, new_rows, N_GRID,
-                                                CT_KERNEL)
+        arg_tuples = self.get_insert_arg_tuples(
+            M_c, T, X_L_list, X_D_list, new_rows, N_GRID, CT_KERNEL)
 
         chain_tuples = self.mapper(self.do_insert, arg_tuples)
         X_L_list, X_D_list = zip(*chain_tuples)
@@ -153,16 +140,15 @@ class LocalEngine(EngineTemplate.EngineTemplate):
             X_L_list, X_D_list = X_L_list[0], X_D_list[0]
 
         T.extend(new_rows)
-
         ret_tuple = X_L_list, X_D_list, T
-
         return ret_tuple
 
-    def get_analyze_arg_tuples(self, M_c, T, X_L_list, X_D_list, kernel_list,
-                               n_steps, c, r, max_iterations, max_time, diagnostic_func_dict,
-                               every_N, ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
-                               S_GRID, MU_GRID, N_GRID, do_timing, CT_KERNEL,
-                               get_next_seed):
+
+    def get_analyze_arg_tuples(
+            self, M_c, T, X_L_list, X_D_list, kernel_list, n_steps, c, r,
+            max_iterations, max_time, diagnostic_func_dict, every_N,
+            ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,
+            do_timing, CT_KERNEL, get_next_seed):
         n_chains = len(X_L_list)
         seeds = [get_next_seed() for seed_idx in range(n_chains)]
         arg_tuples = six.moves.zip(
@@ -199,14 +185,14 @@ class LocalEngine(EngineTemplate.EngineTemplate):
                 do_timing=False,
                 CT_KERNEL=0,
                 ):
-        """Evolve the latent state by running MCMC transition kernels
+        """Evolve the latent state by running MCMC transition kernels.
 
         :param seed: The random seed
         :type seed: int
         :param M_c: The column metadata
         :type M_c: dict
         :param T: The data table in mapped representation (all floats, generated
-                  by data_utils.read_data_objects)
+            by data_utils.read_data_objects)
         :param X_L: the latent variables associated with the latent state
         :type X_L: dict
         :param X_D: the particular cluster assignments of each row in each view
@@ -220,15 +206,12 @@ class LocalEngine(EngineTemplate.EngineTemplate):
         :param r: the (global) row indices to run MCMC transition kernels on
         :type r: list of ints
         :param max_iterations: the maximum number of times ot run each MCMC
-                               transition kernel. Applicable only if
-                               max_time != -1.
+            transition kernel. Applicable only if max_time != -1.
         :type max_iterations: int
         :param max_time: the maximum amount of time (seconds) to run MCMC
-                         transition kernels for before stopping to return
-                         progress
+            transition kernels for before stopping to return progress
         :type max_time: float
         :returns: X_L, X_D -- the evolved latent state
-
         """
         if n_steps <= 0:
             raise ValueError("You must do at least one analyze step.")
@@ -237,308 +220,281 @@ class LocalEngine(EngineTemplate.EngineTemplate):
             raise ValueError("CT_KERNEL must be 0 (Gibbs) or 1 (MH)")
 
         if do_timing:
-            # diagnostics and timing are exclusive
+            # Diagnostics and timing are exclusive.
             do_diagnostics = False
-        diagnostic_func_dict, reprocess_diagnostics_func = do_diagnostics_to_func_dict(
-            do_diagnostics)
+
+        diagnostic_func_dict, reprocess_diagnostics_func = \
+            do_diagnostics_to_func_dict(do_diagnostics)
+
         X_L_list, X_D_list, was_multistate = su.ensure_multistate(X_L, X_D)
-        arg_tuples = self.get_analyze_arg_tuples(M_c, T, X_L_list, X_D_list,
-                                                 kernel_list, n_steps, c, r,
-                                                 max_iterations, max_time,
-                                                 diagnostic_func_dict, diagnostics_every_N,
-                                                 ROW_CRP_ALPHA_GRID,
-                                                 COLUMN_CRP_ALPHA_GRID,
-                                                 S_GRID, MU_GRID,
-                                                 N_GRID,
-                                                 do_timing,
-                                                 CT_KERNEL,
-                                                 make_get_next_seed(seed))
+
+        arg_tuples = self.get_analyze_arg_tuples(
+            M_c, T, X_L_list, X_D_list, kernel_list, n_steps, c, r,
+            max_iterations, max_time, diagnostic_func_dict, diagnostics_every_N,
+            ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,
+            do_timing, CT_KERNEL, make_get_next_seed(seed))
+
         chain_tuples = self.mapper(self.do_analyze, arg_tuples)
+
         X_L_list, X_D_list, diagnostics_dict_list = zip(*chain_tuples)
+
         if do_timing:
             timing_list = diagnostics_dict_list
+
         if not was_multistate:
             X_L_list, X_D_list = X_L_list[0], X_D_list[0]
         ret_tuple = X_L_list, X_D_list
-        #
+
         if diagnostic_func_dict is not None:
             diagnostics_dict = munge_diagnostics(diagnostics_dict_list)
             if reprocess_diagnostics_func is not None:
                 diagnostics_dict = reprocess_diagnostics_func(diagnostics_dict)
             ret_tuple = ret_tuple + (diagnostics_dict, )
+
         if do_timing:
             ret_tuple = ret_tuple + (timing_list, )
+
         return ret_tuple
 
-    def _sample_and_insert(self, M_c, T, X_L, X_D, matching_row_indices,
-                           get_next_seed):
+
+    def _sample_and_insert(
+            self, M_c, T, X_L, X_D, matching_row_indices, get_next_seed):
         p_State = State.p_State(M_c, T, X_L, X_D)
+
         draws = []
+
         for matching_row_idx in matching_row_indices:
             random_seed = get_next_seed()
             draw = p_State.get_draw(matching_row_idx, random_seed)
             p_State.insert_row(draw, matching_row_idx)
             draws.append(draw)
             T.append(draw)
+
         X_L, X_D = p_State.get_X_L(), p_State.get_X_D()
+
         return draws, T, X_L, X_D
 
-    def sample_and_insert(self, M_c, T, X_L, X_D, matching_row_idx,
-                          get_next_seed):
+
+    def sample_and_insert(
+            self, M_c, T, X_L, X_D, matching_row_idx, get_next_seed):
         matching_row_indices = gu.ensure_listlike(matching_row_idx)
+
         if len(matching_row_indices) == 0:
             matching_row_indices = list(range(len(T)))
+
         was_single_row = len(matching_row_indices) == 1
-        draws, T, X_L, X_D = self._sample_and_insert(M_c, T, X_L, X_D, matching_row_indices, get_next_seed)
+
+        draws, T, X_L, X_D = self._sample_and_insert(
+            M_c, T, X_L, X_D, matching_row_indices, get_next_seed)
+
         if was_single_row:
             draws = draws[0]
+
         return draws, T, X_L, X_D
 
     def simple_predictive_sample(self, M_c, X_L, X_D, Y, Q, seed, n=1):
-        """Sample values from the predictive distribution of the given latent state
+        """Sample values from predictive distribution of the given latent state.
 
-        :param seed: The random seed
-        :type seed: int
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L: the latent variables associated with the latent state
-        :type X_L: dict
-        :param X_D: the particular cluster assignments of each row in each view
-        :type X_D: list of lists
         :param Y: A list of constraints to apply when sampling.  Each constraint
-                  is a triplet of (r, d, v): r is the row index, d is the column
-                  index and v is the value of the constraint
+            is a triplet of (r, d, v): r is the row index, d is the column
+            index and v is the value of the constraint
         :type Y: list of lists
         :param Q: A list of values to sample.  Each value is doublet of (r, d):
-                  r is the row index, d is the column index
+            r is the row index, d is the column index
         :type Q: list of lists
         :param n: the number of samples to draw
         :type n: int
-        :returns: list of floats -- samples in the same order specified by Q
 
+        :returns: list of floats.  Samples in the same order specified by Q
         """
         get_next_seed = make_get_next_seed(seed)
         samples = _do_simple_predictive_sample(
             M_c, X_L, X_D, Y, Q, n, get_next_seed)
         return samples
 
-    def simple_predictive_probability(self, M_c, X_L, X_D, Y, Q):
-        """Calculate the probability of a cell taking a value given a latent state
 
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L: the latent variables associated with the latent state
-        :type X_L: dict
-        :param X_D: the particular cluster assignments of each row in each view
-        :type X_D: list of lists
+    def simple_predictive_probability(self, M_c, X_L, X_D, Y, Q):
+        """Calculate probability of a cell taking a value given a latent state.
+
         :param Y: A list of constraints to apply when querying.  Each constraint
-                  is a triplet of (r, d, v): r is the row index, d is the column
-                  index and v is the value of the constraint
+            is a triplet of (r, d, v): r is the row index, d is the column
+            index and v is the value of the constraint
         :type Y: list of lists
         :param Q: A list of values to query.  Each value is triplet of (r, d, v):
-                  r is the row index, d is the column index, and v is the value at
-                  which the density is evaluated.
+            r is the row index, d is the column index, and v is the value at
+            which the density is evaluated.
         :type Q: list of lists
-        :returns: list of floats -- probabilities of the values specified by Q
 
+        :returns: list of floats -- probabilities of the values specified by Q
         """
         return su.simple_predictive_probability(M_c, X_L, X_D, Y, Q)
 
-    def simple_predictive_probability_multistate(self, M_c, X_L_list, X_D_list, Y, Q):
-        """Calculate the probability of a cell taking a value given a latent state
 
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L_list: list of the latent variables associated with the latent state
-        :type X_L_list: list of dict
-        :param X_D_list: list of the particular cluster assignments of each row in each view
-        :type X_D_list: list of list of lists
+    def simple_predictive_probability_multistate(
+            self, M_c, X_L_list, X_D_list, Y, Q):
+        """Calculate probability of a cell taking a value given a latent state.
+
         :param Y: A list of constraints to apply when querying.  Each constraint
-                  is a triplet of (r,d,v): r is the row index, d is the column
-                  index and v is the value of the constraint
+            is a triplet of (r,d,v): r is the row index, d is the column
+            index and v is the value of the constraint
         :type Y: list of lists
-        :param Q: A list of values to query.  Each value is triplet of (r,d,v):
-                  r is the row index, d is the column index, and v is the value at
-                  which the density is evaluated.
-        :type Q: list of lists
-        :returns: list of floats -- probabilities of the values specified by Q
 
+        :param Q: A list of values to query.  Each value is triplet of (r,d,v):
+            r is the row index, d is the column index, and v is the value at
+            which the density is evaluated.
+        :type Q: list of lists
+
+        :returns: list of floats -- probabilities of the values specified by Q
         """
-        return su.simple_predictive_probability_multistate(M_c, X_L_list, X_D_list, Y, Q)
+        return su.simple_predictive_probability_multistate(
+            M_c, X_L_list, X_D_list, Y, Q)
+
 
     def predictive_probability(self, M_c, X_L, X_D, Y, Q):
-        """Calculate the probability of cellS jointly taking values given a latent state
+        """Calculate probability of cells jointly taking values given a
+        latent state.
 
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L: the latent variables associated with the latent state
-        :type X_L: dict
-        :param X_D: the particular cluster assignments of each row in each view
-        :type X_D: list of lists
         :param Y: A list of constraints to apply when querying.  Each constraint
-                  is a triplet of (r, d, v): r is the row index, d is the column
-                  index and v is the value of the constraint
+            is a triplet of (r, d, v): r is the row index, d is the column
+            index and v is the value of the constraint
         :type Y: list of lists
         :param Q: A list of values to query.  Each value is triplet of (r, d, v):
-                  r is the row index, d is the column index, and v is the value at
-                  which the density is evaluated.
+            r is the row index, d is the column index, and v is the value at
+            which the density is evaluated.
         :type Q: list of lists
-        :returns: float -- joint log probability of the values specified by Q
 
+        :returns: float -- joint log probability of the values specified by Q
         """
         return su.predictive_probability(M_c, X_L, X_D, Y, Q)
 
-    def predictive_probability_multistate(self, M_c, X_L_list, X_D_list, Y, Q):
-        """Calculate the probability of cellS jointly taking values given a latent state
 
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L_list: list of the latent variables associated with the latent state
-        :type X_L_list: list of dict
-        :param X_D_list: list of the particular cluster assignments of each row in each view
-        :type X_D_list: list of list of lists
+    def predictive_probability_multistate(self, M_c, X_L_list, X_D_list, Y, Q):
+        """Calculate probability of cells jointly taking values given a
+        latent state.
+
         :param Y: A list of constraints to apply when querying.  Each constraint
-                  is a triplet of (r,d,v): r is the row index, d is the column
-                  index and v is the value of the constraint
+            is a triplet of (r,d,v): r is the row index, d is the column
+            index and v is the value of the constraint
         :type Y: list of lists
         :param Q: A list of values to query.  Each value is triplet of (r,d,v):
-                  r is the row index, d is the column index, and v is the value at
-                  which the density is evaluated.
+            r is the row index, d is the column index, and v is the value at
+            which the density is evaluated.
         :type Q: list of lists
+
         :returns: float -- joint log probabilities of the values specified by Q
-
         """
-        return su.predictive_probability_multistate(M_c, X_L_list, X_D_list, Y, Q)
+        return su.predictive_probability_multistate(
+            M_c, X_L_list, X_D_list, Y, Q)
 
-    def mutual_information(self, M_c, X_L_list, X_D_list, Q, seed,
-                           n_samples=1000):
-        """
-        Return the estimated mutual information for each pair of columns on Q given
+
+    def mutual_information(
+            self, M_c, X_L_list, X_D_list, Q, seed, n_samples=1000):
+        """Estimate mutual information for each pair of columns on Q given
         the set of samples.
 
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L_list: list of the latent variables associated with the latent state
-        :type X_L_list: list of dict
-        :param X_D_list: list of the particular cluster assignments of each row in each view
-        :type X_D_list: list of list of lists
-        :param Q: List of tuples where each tuple contains the two column indexes to compare
+        :param Q: List of tuples where each tuple contains the two column
+            indexes to compare
         :type Q: list of two-tuples of ints
         :param n_samples: the number of simple predictive samples to use
         :type n_samples: int
-        :returns: list of list, where each sublist is a set of MIs and Linfoots from each crosscat
-        sample.
+
+        :returns: list of list -- where each sublist is a set of MIs and
+            Linfoots from each crosscat sample.
         """
         get_next_seed = make_get_next_seed(seed)
-        return iu.mutual_information(M_c, X_L_list, X_D_list, Q,
-                                     get_next_seed, n_samples)
+        return iu.mutual_information(
+            M_c, X_L_list, X_D_list, Q, get_next_seed, n_samples)
+
 
     def row_structural_typicality(self, X_L_list, X_D_list, row_id):
-        """
-        Returns the typicality (opposite of anomalousness) of the given row.
+        """Returns the typicality (opposite of anomalousness) of given row.
 
-        :param X_L_list: list of the latent variables associated with the latent state
-        :type X_L_list: list of dict
-        :param X_D_list: list of the particular cluster assignments of each row in each view
-        :type X_D_list: list of list of lists
         :param row_id: id of the target row
         :type row_id: int
+
         :returns: float, the typicality, from 0 to 1
         """
         return su.row_structural_typicality(X_L_list, X_D_list, row_id)
 
-    def column_structural_typicality(self, X_L_list, col_id):
-        """
-        Returns the typicality (opposite of anomalousness) of the given column.
 
-        :param X_L_list: list of the latent variables associated with the latent state
-        :type X_L_list: list of dict
+    def column_structural_typicality(self, X_L_list, col_id):
+        """Returns the typicality (opposite of anomalousness) of given column.
+
         :param col_id: id of the target col
         :type col_id: int
+
         :returns: float, the typicality, from 0 to 1
         """
         return su.column_structural_typicality(X_L_list, col_id)
 
-    def similarity(self, M_c, X_L_list, X_D_list, given_row_id, target_row_id, target_columns=None):
-        """Computes the similarity of the given row to the target row, averaged over all the
-        column indexes given by target_columns.
 
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L: list of the latent variables associated with the latent state
-        :type X_L: list of dicts
-        :param X_D: list of the particular cluster assignments of each row in each view
-        :type X_D: list of list of lists
-        :param given_row_id: the id of one of the rows to measure similarity between
+    def similarity(
+            self, M_c, X_L_list, X_D_list, given_row_id, target_row_id,
+            target_columns=None):
+        """Computes the similarity of the given row to the target row,
+        averaged over all the column indexes given by target_columns.
+
+        :param given_row_id: the id of one of the rows to measure similarity
+            between
         :type given_row_id: int
-        :param target_row_id: the id of the other row to measure similarity between
+        :param target_row_id: the id of the other row to measure similarity
+            between
         :type target_row_id: int
-        :param target_columns: the columns to average the similarity over. defaults to all columns.
+        :param target_columns: the columns to average the similarity over.
+            Defaults to all columns.
         :type target_columns: int, string, or list of ints
-        :returns: float
 
+        :returns: float
         """
-        return su.similarity(M_c, X_L_list, X_D_list, given_row_id, target_row_id, target_columns)
+        return su.similarity(
+            M_c, X_L_list, X_D_list, given_row_id,
+            target_row_id, target_columns)
+
 
     def impute(self, M_c, X_L, X_D, Y, Q, seed, n):
-        """Impute values from the predictive distribution of the given latent state
+        """Impute values from predictive distribution of the given latent state.
 
-        :param seed: The random seed
-        :type seed: int
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L: the latent variables associated with the latent state
-        :type X_L: dict
-        :param X_D: the particular cluster assignments of each row in each view
-        :type X_D: list of lists
         :param Y: A list of constraints to apply when sampling.  Each constraint
-                  is a triplet of (r,d,v): r is the row index, d is the column
-                  index and v is the value of the constraint
+            is a triplet of (r,d,v): r is the row index, d is the column
+            index and v is the value of the constraint
         :type Y: list of lists
         :param Q: A list of values to sample.  Each value is doublet of (r, d):
                   r is the row index, d is the column index
         :type Q: list of lists
         :param n: the number of samples to use in the imputation
         :type n: int
-        :returns: list of floats -- imputed values in the same order as
-                  specified by Q
 
+        :returns: list of floats -- imputed values in the same order as
+            specified by Q
         """
         get_next_seed = make_get_next_seed(seed)
         e = su.impute(M_c, X_L, X_D, Y, Q, n, get_next_seed)
         return e
 
+
     def impute_and_confidence(self, M_c, X_L, X_D, Y, Q, seed, n):
         """Impute values and confidence of the value from the predictive
-        distribution of the given latent state
+        distribution of the given latent state.
 
-        :param seed: The random seed
-        :type seed: int
-        :param M_c: The column metadata
-        :type M_c: dict
-        :param X_L: the latent variables associated with the latent state
-        :type X_L: dict
-        :param X_D: the particular cluster assignments of each row in each view
-        :type X_D: list of lists
         :param Y: A list of constraints to apply when sampling.  Each constraint
-                  is a triplet of (r, d, v): r is the row index, d is the column
-                  index and v is the value of the constraint
+            is a triplet of (r, d, v): r is the row index, d is the column
+            index and v is the value of the constraint
         :type Y: list of lists
         :param Q: A list of values to sample.  Each value is doublet of (r, d):
-                  r is the row index, d is the column index
+            r is the row index, d is the column index
         :type Q: list of lists
         :param n: the number of samples to use in the imputation
         :type n: int
-        :returns: list of lists -- list of (value, confidence) tuples in the
-                  same order as specified by Q
 
+        :returns: list of lists -- list of (value, confidence) tuples in the
+            same order as specified by Q
         """
         get_next_seed = make_get_next_seed(seed)
         if isinstance(X_L, (list, tuple)):
             assert isinstance(X_D, (list, tuple))
             # TODO: multistate impute doesn't exist yet
-            # e,confidence = su.impute_and_confidence_multistate(M_c, X_L, X_D, Y, Q, n,
-            #                                                    self.get_next_seed)
+            # e,confidence = su.impute_and_confidence_multistate(
+            #   M_c, X_L, X_D, Y, Q, n, self.get_next_seed)
             e, confidence = su.impute_and_confidence(
                 M_c, X_L, X_D, Y, Q, n, get_next_seed)
         else:
@@ -546,21 +502,23 @@ class LocalEngine(EngineTemplate.EngineTemplate):
                 M_c, X_L, X_D, Y, Q, n, get_next_seed)
         return (e, confidence)
 
-    def ensure_col_dep_constraints(self, M_c, M_r, T, X_L, X_D,
-            dep_constraints, seed, max_rejections=100):
+
+    def ensure_col_dep_constraints(
+            self, M_c, M_r, T, X_L, X_D, dep_constraints,
+            seed, max_rejections=100):
         """Ensures dependencey or indepdendency between columns.
 
-        dep_constraints is a list of where each entry is an (int, int, bool) tuple
-        where the first two entries are column indices and the third entry
+        `dep_constraints` is a list of where each entry is an (int, int, bool)
+        tuple where the first two entries are column indices and the third entry
         describes whether the columns are to be dependent (True) or independent
         (False).
 
         Behavior Notes:
-        ensure_col_dep_constraints will add col_esnure enforcement to the
-        metadata (top level of X_L); unensure_col will remove it. Calling
+        `ensure_col_dep_constraints` will add `col_ensure` enforcement to the
+        metadata (top level of `X_L`); unensure_col will remove it. Calling
         ensure_col_dep_constraints twice will replace the first ensure.
 
-        This operation destroys the existing X_L and X_D metadata; the user
+        This operation destroys the existing `X_L` and `X_D` metadata; the user
         should be aware that it will clobber any existing analyses.
 
         Implementation Notes:
@@ -574,19 +532,19 @@ class LocalEngine(EngineTemplate.EngineTemplate):
         [(1, 2, True), (2, 5, True), (1, 5, True), (1, 3, False)]
         >>> X_L['col_ensure']
         {
-            "dependent" :
-            {
+            "dependent" : {
                 1 : [2, 5],
                 2 : [1, 5],
                 5 : [1, 2]
             },
-            "independent" :
-            {
+            "independent" : {
                 1 : [3],
                 3 : [1]
+            }
         }
         """
         X_L_list, X_D_list, was_multistate = su.ensure_multistate(X_L, X_D)
+
         if was_multistate:
             num_states = len(X_L_list)
         else:
@@ -598,8 +556,9 @@ class LocalEngine(EngineTemplate.EngineTemplate):
 
         for col1, col2, dependent in dep_constraints:
             if col1 == col2:
-                raise ValueError("Cannot specify same columns in dependence"\
-                    " constraints.")
+                raise ValueError(
+                    'Cannot specify same columns in dependence '
+                    'constraints.')
             if str(col1) in col_ensure_md[dependent]:
                 col_ensure_md[dependent][str(col1)].append(col2)
             else:
@@ -611,21 +570,23 @@ class LocalEngine(EngineTemplate.EngineTemplate):
 
         def assert_dep_constraints(X_L, X_D, dep_constraints):
             for col1, col2, dep in dep_constraints:
-                if not self.assert_col_dep_constraints(X_L, X_D, col1, col2,
-                    dep, True):
+                if not self.assert_col_dep_constraints(
+                        X_L, X_D, col1, col2, dep, True):
                     return False
             return True
 
         X_L_out = []
         X_D_out = []
         get_next_seed = make_get_next_seed(seed)
+
         for _ in range(num_states):
             counter = 0
             X_L_i, X_D_i = self.initialize(M_c, M_r, T, get_next_seed())
             while not assert_dep_constraints(X_L_i, X_D_i, dep_constraints):
                 if counter > max_rejections:
-                    raise RuntimeError("Could not ranomly generate a partition"\
-                        " that satisfies the constraints in dep_constraints.")
+                    raise RuntimeError(
+                        'Could not ranomly generate a partition '
+                        'that satisfies the constraints in dep_constraints.')
                 counter += 1
                 X_L_i, X_D_i = self.initialize(M_c, M_r, T, get_next_seed())
 
@@ -641,28 +602,38 @@ class LocalEngine(EngineTemplate.EngineTemplate):
         else:
             return X_L_out[0], X_D_out[0]
 
-    def ensure_row_dep_constraint(self, M_c, T, X_L, X_D, row1, row2,
-            dependent=True, wrt=None, max_iter=100, force=False):
+
+    def ensure_row_dep_constraint(
+            self, M_c, T, X_L, X_D, row1, row2, dependent=True, wrt=None,
+            max_iter=100, force=False):
         """Ensures dependencey or indepdendency between rows with respect to
-        (wrt) columns."""
+        columns."""
         X_L_list, X_D_list, was_multistate = su.ensure_multistate(X_L, X_D)
+
         if force:
             raise NotImplementedError
         else:
             kernel_list = ('row_partition_assignements',)
             for i, (X_L_i, X_D_i) in enumerate(zip(X_L_list, X_D_list)):
+
                 iters = 0
                 X_L_tmp = copy.deepcopy(X_L_i)
                 X_D_tmp = copy.deepcopy(X_D_i)
-                while not self.assert_row(X_L_tmp, X_D_tmp, row1, row2,
+
+                while not self.assert_row(
+                        X_L_tmp, X_D_tmp, row1, row2,
                         dependent=dependent, wrt=wrt):
                     if iters >= max_iter:
-                        raise RuntimeError('Maximum ensure iterations reached.')
-                    res = self.analyze(M_c, T, X_L_i, X_D_i, kernel_list=kernel_list,
+                        raise RuntimeError(
+                            'Maximum ensure iterations reached.')
+                    # XXX No seed?
+                    res = self.analyze(
+                        M_c, T, X_L_i, X_D_i, kernel_list=kernel_list,
                         n_steps=1, r=(row1,))
                     X_L_tmp = res[0]
                     X_D_tmp = res[1]
                     iters += 1
+
                 X_L_list[i] = X_L_tmp
                 X_D_list[i] = X_D_tmp
 
@@ -671,14 +642,16 @@ class LocalEngine(EngineTemplate.EngineTemplate):
         else:
             return X_L_list[0], X_D_list[0]
 
-    def assert_col_dep_constraints(self, X_L, X_D, col1, col2, dependent=True,
-        single_bool=False):
+
+    def assert_col_dep_constraints(
+            self, X_L, X_D, col1, col2, dependent=True, single_bool=False):
         # TODO: X_D is not used for anything other than ensure_multistate.
         # I should probably edit ensure_multistate to take X_L or X_D using
         # keyword arguments.
         X_L_list, _, was_multistate = su.ensure_multistate(X_L, X_D)
         model_assertions = []
         assertion = True
+
         for X_L_i in X_L_list:
             assg = X_L_i['column_partition']['assignments']
             assertion = (assg[col1] == assg[col2]) == dependent
@@ -696,13 +669,16 @@ class LocalEngine(EngineTemplate.EngineTemplate):
 
     def assert_row(self, X_L, X_D, row1, row2, dependent=True, wrt=None):
         X_L_list, X_D_list, was_multistate = su.ensure_multistate(X_L, X_D)
+
         if wrt is None:
             num_cols = len(X_L_list[0]['column_partition']['assignments'])
             wrt = list(range(num_cols))
         else:
             if not isinstance(wrt, list):
                 raise TypeError('wrt must be a list')
+
         model_assertions = []
+
         for X_L_i, X_D_i in zip(X_L_list, X_D_list):
             view_assg = X_L_i['column_partition']['assignments']
             views_wrt = list(set([view_assg[col] for col in wrt]))
@@ -723,6 +699,7 @@ class LocalEngine(EngineTemplate.EngineTemplate):
 def do_diagnostics_to_func_dict(do_diagnostics):
     diagnostic_func_dict = None
     reprocess_diagnostics_func = None
+
     if do_diagnostics:
         if isinstance(do_diagnostics, (dict,)):
             diagnostic_func_dict = do_diagnostics
@@ -731,6 +708,7 @@ def do_diagnostics_to_func_dict(do_diagnostics):
         if 'reprocess_diagnostics_func' in diagnostic_func_dict:
             reprocess_diagnostics_func = diagnostic_func_dict.pop(
                 'reprocess_diagnostics_func')
+
     return diagnostic_func_dict, reprocess_diagnostics_func
 
 
@@ -742,28 +720,28 @@ def munge_diagnostics(diagnostics_dict_list):
     # all dicts should have the same keys
     diagnostic_names = diagnostics_dict_list[0].keys()
     diagnostics_dict = {
-        diagnostic_name: get_value_in_each_dict(diagnostic_name, diagnostics_dict_list)
+        diagnostic_name:
+            get_value_in_each_dict(diagnostic_name, diagnostics_dict_list)
         for diagnostic_name in diagnostic_names
     }
     return diagnostics_dict
 
-# switched ordering so args that change come first
+
+# Switched ordering so args that change come first.
 # FIXME: change LocalEngine.initialze to match ordering here
 
 
-def _do_initialize(SEED, M_c, M_r, T, initialization, row_initialization,
-                   ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
-                   S_GRID, MU_GRID,
-                   N_GRID,
-                   ):
-    p_State = State.p_State(M_c, T, initialization=initialization,
-                            row_initialization=row_initialization, SEED=SEED,
-                            ROW_CRP_ALPHA_GRID=ROW_CRP_ALPHA_GRID,
-                            COLUMN_CRP_ALPHA_GRID=COLUMN_CRP_ALPHA_GRID,
-                            S_GRID=S_GRID,
-                            MU_GRID=MU_GRID,
-                            N_GRID=N_GRID,
-                            )
+def _do_initialize(
+        SEED, M_c, M_r, T, initialization, row_initialization,
+         ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID,):
+
+    p_State = State.p_State(
+        M_c, T, initialization=initialization,
+        row_initialization=row_initialization, SEED=SEED,
+        ROW_CRP_ALPHA_GRID=ROW_CRP_ALPHA_GRID,
+        COLUMN_CRP_ALPHA_GRID=COLUMN_CRP_ALPHA_GRID, S_GRID=S_GRID,
+        MU_GRID=MU_GRID, N_GRID=N_GRID,)
+
     X_L = p_State.get_X_L()
     X_D = p_State.get_X_D()
     return X_L, X_D
@@ -778,41 +756,38 @@ def _do_insert_tuple(arg_tuple):
 
 
 def _do_insert(M_c, T, X_L, X_D, new_rows, N_GRID, CT_KERNEL):
-    p_State = State.p_State(M_c, T, X_L=X_L, X_D=X_D,
-                            N_GRID=N_GRID,
-                            CT_KERNEL=CT_KERNEL)
+    p_State = State.p_State(
+        M_c, T, X_L=X_L, X_D=X_D, N_GRID=N_GRID, CT_KERNEL=CT_KERNEL)
 
     row_idx = len(T)
     for row_data in new_rows:
         p_State.insert_row(row_data, row_idx)
-        p_State.transition(which_transitions=['row_partition_assignments'], r=[row_idx])
+        p_State.transition(
+            which_transitions=['row_partition_assignments'], r=[row_idx])
         row_idx += 1
 
     X_L_prime = p_State.get_X_L()
     X_D_prime = p_State.get_X_D()
     return X_L_prime, X_D_prime
 
-# switched ordering so args that change come first
+
+# Switched ordering so args that change come first.
 # FIXME: change LocalEngine.analyze to match ordering here
 
 
-def _do_analyze(SEED, X_L, X_D, M_c, T, kernel_list, n_steps, c, r,
-                max_iterations, max_time,
-                ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
-                S_GRID, MU_GRID,
-                N_GRID,
-                CT_KERNEL,
-                ):
-    p_State = State.p_State(M_c, T, X_L, X_D, SEED=SEED,
-                            ROW_CRP_ALPHA_GRID=ROW_CRP_ALPHA_GRID,
-                            COLUMN_CRP_ALPHA_GRID=COLUMN_CRP_ALPHA_GRID,
-                            S_GRID=S_GRID,
-                            MU_GRID=MU_GRID,
-                            N_GRID=N_GRID,
-                            CT_KERNEL=CT_KERNEL
-                            )
-    p_State.transition(kernel_list, n_steps, c, r,
-                       max_iterations, max_time)
+def _do_analyze(
+        SEED, X_L, X_D, M_c, T, kernel_list, n_steps, c, r,
+        max_iterations, max_time, ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
+        S_GRID, MU_GRID, N_GRID, CT_KERNEL):
+
+    p_State = State.p_State(
+        M_c, T, X_L, X_D, SEED=SEED, ROW_CRP_ALPHA_GRID=ROW_CRP_ALPHA_GRID,
+        COLUMN_CRP_ALPHA_GRID=COLUMN_CRP_ALPHA_GRID, S_GRID=S_GRID,
+        MU_GRID=MU_GRID, N_GRID=N_GRID, CT_KERNEL=CT_KERNEL)
+
+    p_State.transition(
+        kernel_list, n_steps, c, r, max_iterations, max_time)
+
     X_L_prime = p_State.get_X_L()
     X_D_prime = p_State.get_X_D()
     return X_L_prime, X_D_prime
@@ -824,155 +799,88 @@ def _do_analyze_tuple(arg_tuple):
 
 def get_child_n_steps_list(n_steps, every_N):
     if every_N is None:
-        # results in one block of size n_steps
+        # Results in one block of size n_steps.
         every_N = n_steps
     missing_endpoint = numpy.arange(0, n_steps, every_N)
     with_endpoint = numpy.append(missing_endpoint, n_steps)
     child_n_steps_list = numpy.diff(with_endpoint)
     return child_n_steps_list.tolist()
 
+
 none_summary = lambda p_State: None
 
-# switched ordering so args that change come first
+
+# Switched ordering so args that change come first.
 # FIXME: change LocalEngine.analyze to match ordering here
 
 
-def _do_analyze_with_diagnostic(SEED, X_L, X_D, M_c, T, kernel_list, n_steps, c, r,
-                                max_iterations, max_time, diagnostic_func_dict, every_N,
-                                ROW_CRP_ALPHA_GRID, COLUMN_CRP_ALPHA_GRID,
-                                S_GRID, MU_GRID,
-                                N_GRID,
-                                do_timing,
-                                CT_KERNEL,
-                                ):
+def _do_analyze_with_diagnostic(
+        SEED, X_L, X_D, M_c, T, kernel_list, n_steps, c, r, max_iterations,
+        max_time, diagnostic_func_dict, every_N, ROW_CRP_ALPHA_GRID,
+        COLUMN_CRP_ALPHA_GRID, S_GRID, MU_GRID, N_GRID, do_timing, CT_KERNEL,):
+
     diagnostics_dict = collections.defaultdict(list)
+
     if diagnostic_func_dict is None:
         diagnostic_func_dict = dict()
         every_N = None
+
     child_n_steps_list = get_child_n_steps_list(n_steps, every_N)
-    # import ipdb; ipdb.set_trace()
-    p_State = State.p_State(M_c, T, X_L, X_D, SEED=SEED,
-                            ROW_CRP_ALPHA_GRID=ROW_CRP_ALPHA_GRID,
-                            COLUMN_CRP_ALPHA_GRID=COLUMN_CRP_ALPHA_GRID,
-                            S_GRID=S_GRID,
-                            MU_GRID=MU_GRID,
-                            N_GRID=N_GRID,
-                            CT_KERNEL=CT_KERNEL,
-                            )
+
+    p_State = State.p_State(
+        M_c, T, X_L, X_D, SEED=SEED, ROW_CRP_ALPHA_GRID=ROW_CRP_ALPHA_GRID,
+        COLUMN_CRP_ALPHA_GRID=COLUMN_CRP_ALPHA_GRID, S_GRID=S_GRID,
+        MU_GRID=MU_GRID, N_GRID=N_GRID, CT_KERNEL=CT_KERNEL)
+
     with gu.Timer('all transitions', verbose=False) as timer:
         # XXX If doing diagnostics (i.e. invoking from bayeslite) skip the
         # progress bar.
         progress = len(child_n_steps_list) == 1
         for child_n_steps in child_n_steps_list:
-            p_State.transition(kernel_list, child_n_steps, c, r,
-                               max_iterations, max_time, progress=progress)
-            for diagnostic_name, diagnostic_func in six.iteritems(diagnostic_func_dict):
+            p_State.transition(
+                kernel_list, child_n_steps, c, r, max_iterations,
+                max_time, progress=progress)
+            for diagnostic_name, diagnostic_func in\
+                    six.iteritems(diagnostic_func_dict):
                 diagnostic_value = diagnostic_func(p_State)
                 diagnostics_dict[diagnostic_name].append(diagnostic_value)
-                pass
-            pass
-        pass
+
     X_L_prime = p_State.get_X_L()
     X_D_prime = p_State.get_X_D()
-    #
+
     if do_timing:
-        # diagnostics and timing are exclusive
+        # Diagnostics and timing are exclusive.
         diagnostics_dict = timer.elapsed_secs
-        pass
+
     return X_L_prime, X_D_prime, diagnostics_dict
 
 
 def _do_simple_predictive_sample(M_c, X_L, X_D, Y, Q, n, get_next_seed):
     is_multistate = su.get_is_multistate(X_L, X_D)
     if is_multistate:
-        samples = su.simple_predictive_sample_multistate(M_c, X_L, X_D, Y, Q,
-                                                         get_next_seed, n)
+        samples = su.simple_predictive_sample_multistate(
+            M_c, X_L, X_D, Y, Q, get_next_seed, n)
     else:
-        samples = su.simple_predictive_sample(M_c, X_L, X_D, Y, Q,
-                                              get_next_seed, n)
+        samples = su.simple_predictive_sample(
+            M_c, X_L, X_D, Y, Q, get_next_seed, n)
     return samples
 
 
-default_diagnostic_func_dict = dict(
-    # fully qualify path b/c dview.sync_imports can't deal with 'as'
-    # imports
-    logscore=crosscat.utils.diagnostic_utils.get_logscore,
-    num_views=crosscat.utils.diagnostic_utils.get_num_views,
-    column_crp_alpha=crosscat.utils.diagnostic_utils.get_column_crp_alpha,
-    # any outputs required by reproess_diagnostics_func must be generated
-    # as well
-    column_partition_assignments=crosscat.utils.diagnostic_utils.get_column_partition_assignments,
-    reprocess_diagnostics_func=crosscat.utils.diagnostic_utils.default_reprocess_diagnostics_func,
-)
+default_diagnostic_func_dict = {
+    # Fully qualify path because dview.sync_imports cannot deal with 'as'
+    # imports.
+    'logscore':crosscat.utils.diagnostic_utils.get_logscore,
+    'num_views':crosscat.utils.diagnostic_utils.get_num_views,
+    'column_crp_alpha':crosscat.utils.diagnostic_utils.get_column_crp_alpha,
+    # Any outputs required by reproess_diagnostics_func must be generated
+    # as well.
+    'column_partition_assignments':
+        crosscat.utils.diagnostic_utils.get_column_partition_assignments,
+    'reprocess_diagnostics_func':
+        crosscat.utils.diagnostic_utils.default_reprocess_diagnostics_func
+}
 
 
 def make_get_next_seed(seed):
     generator = gu.int_generator(seed)
     return lambda: generator.next()
-
-
-if __name__ == '__main__':
-    import crosscat.utils.data_utils as du
-    import crosscat.utils.convergence_test_utils as ctu
-
-    # settings
-    gen_seed = 0
-    inf_seed = 0
-    num_clusters = 4
-    num_cols = 32
-    num_rows = 400
-    num_views = 2
-    n_steps = 1
-    n_times = 5
-    n_chains = 3
-    n_test = 100
-    CT_KERNEL = 1
-
-    get_next_seed = make_get_next_seed(gen_seed)
-
-    # generate some data
-    T, M_r, M_c, data_inverse_permutation_indices = du.gen_factorial_data_objects(
-        get_next_seed(), num_clusters, num_cols, num_rows, num_views,
-        max_mean=100, max_std=1, send_data_inverse_permutation_indices=True)
-    view_assignment_truth, X_D_truth = ctu.truth_from_permute_indices(
-        data_inverse_permutation_indices, num_rows, num_cols, num_views, num_clusters)
-
-    # run some tests
-    engine = LocalEngine()
-    multi_state_ARIs = []
-    multi_state_mean_test_lls = []
-    X_L_list, X_D_list = engine.initialize(M_c, M_r, T, get_next_seed(),
-        n_chains=n_chains)
-    multi_state_ARIs.append(
-        ctu.get_column_ARIs(X_L_list, view_assignment_truth))
-
-    for time_i in range(n_times):
-        X_L_list, X_D_list = engine.analyze(
-            M_c, T, X_L_list, X_D_list, get_next_seed(), n_steps=n_steps,
-            CT_KERNEL=CT_KERNEL)
-        multi_state_ARIs.append(
-            ctu.get_column_ARIs(X_L_list, view_assignment_truth))
-        # multi_state_mean_test_lls.append(
-        #     ctu.calc_mean_test_log_likelihoods(M_c, T,
-        #                                        X_L_list, X_D_list, T_test))
-
-    X_L_list, X_D_list, diagnostics_dict = engine.analyze(
-        M_c, T, X_L_list, X_D_list, get_next_seed(),
-        n_steps=n_steps, do_diagnostics=True)
-
-    # print results
-    ct_kernel_name = 'UNKNOWN'
-    if CT_KERNEL == 0:
-        ct_kernel_name = 'GIBBS'
-    elif CT_KERNEL == 1:
-        ct_kernel_name = 'METROPOLIS'
-
-    print('Running with %s CT_KERNEL' % ct_kernel_name)
-    print('generative_mean_test_log_likelihood')
-    # print generative_mean_test_log_likelihood
-    #
-    print('multi_state_mean_test_lls:')
-    print(multi_state_mean_test_lls)
-    #
-    print('multi_state_ARIs:')
-    print(multi_state_ARIs)

--- a/src/MultiprocessingEngine.py
+++ b/src/MultiprocessingEngine.py
@@ -17,28 +17,28 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
 from __future__ import print_function
+
 import multiprocessing
-#
+
 import crosscat.LocalEngine as LE
 import crosscat.utils.sample_utils as su
 
 
 class MultiprocessingEngine(LE.LocalEngine):
-    """A simple interface to the Cython-wrapped C++ engine
+    """A simple interface to the Cython-wrapped C++ engine.
 
     MultiprocessingEngine holds no state.
     Methods use resources on the local machine.
     """
 
     def __init__(self, seed=None, cpu_count=None):
-        """Initialize a MultiprocessingEngine
-        """
         super(MultiprocessingEngine, self).__init__(seed=None)
         self.pool = multiprocessing.Pool(cpu_count)
         self.mapper = self.pool.map
         return
-    
+
     def __enter__(self):
         return self
 
@@ -47,88 +47,3 @@ class MultiprocessingEngine(LE.LocalEngine):
 
     def __exit__(self, type, value, traceback):
         self.pool.terminate()
-
-
-if __name__ == '__main__':
-    import crosscat.utils.data_utils as du
-    import crosscat.utils.convergence_test_utils as ctu
-    import random
-
-
-    # settings
-    gen_seed = 0
-    inf_seed = 0
-    num_clusters = 4
-    num_cols = 32
-    num_rows = 400
-    num_views = 2
-    n_steps = 1
-    n_times = 5
-    n_chains = 3
-    n_test = 100
-
-    rng = random.Random(gen_seed)
-    get_next_seed = lambda: rng.randint(1, 2**31 - 1)
-
-    # generate some data
-    T, M_r, M_c, data_inverse_permutation_indices = du.gen_factorial_data_objects(
-            get_next_seed(), num_clusters, num_cols, num_rows, num_views,
-            max_mean=100, max_std=1, send_data_inverse_permutation_indices=True)
-    view_assignment_truth, X_D_truth = ctu.truth_from_permute_indices(
-            data_inverse_permutation_indices, num_rows, num_cols, num_views, num_clusters)
-    X_L_gen, X_D_gen = du.get_generative_clustering(get_next_seed(),
-            M_c, M_r, T,
-            data_inverse_permutation_indices, num_clusters, num_views)
-    T_test = ctu.create_test_set(M_c, T, X_L_gen, X_D_gen, n_test, seed_seed=0)
-    #
-    generative_mean_test_log_likelihood = ctu.calc_mean_test_log_likelihood(M_c, T,
-            X_L_gen, X_D_gen, T_test)
-
-
-    # run some tests
-    engine = MultiprocessingEngine()
-    # single state test
-    single_state_ARIs = []
-    single_state_mean_test_lls = []
-    X_L, X_D = engine.initialize(M_c, M_r, T, get_next_seed(), n_chains=1)
-    single_state_ARIs.append(ctu.get_column_ARI(X_L, view_assignment_truth))
-    single_state_mean_test_lls.append(
-            ctu.calc_mean_test_log_likelihood(M_c, T, X_L, X_D, T_test)
-            )
-    for time_i in range(n_times):
-        X_L, X_D = engine.analyze(M_c, T, X_L, X_D, get_next_seed(),
-            n_steps=n_steps)
-        single_state_ARIs.append(ctu.get_column_ARI(X_L, view_assignment_truth))
-        single_state_mean_test_lls.append(
-            ctu.calc_mean_test_log_likelihood(M_c, T, X_L, X_D, T_test)
-            )
-    # multistate test
-    multi_state_ARIs = []
-    multi_state_mean_test_lls = []
-    X_L_list, X_D_list = engine.initialize(M_c, M_r, T, get_next_seed(),
-        n_chains=n_chains)
-    multi_state_ARIs.append(ctu.get_column_ARIs(X_L_list, view_assignment_truth))
-    multi_state_mean_test_lls.append(ctu.calc_mean_test_log_likelihoods(M_c, T,
-        X_L_list, X_D_list, T_test))
-    for time_i in range(n_times):
-        X_L_list, X_D_list = engine.analyze(M_c, T, X_L_list, X_D_list,
-            get_next_seed(), n_steps=n_steps)
-        multi_state_ARIs.append(ctu.get_column_ARIs(X_L_list, view_assignment_truth))
-        multi_state_mean_test_lls.append(ctu.calc_mean_test_log_likelihoods(M_c, T,
-            X_L_list, X_D_list, T_test))
-
-    # print results
-    print('generative_mean_test_log_likelihood')
-    print(generative_mean_test_log_likelihood)
-    #
-    print('single_state_mean_test_lls:')
-    print(single_state_mean_test_lls)
-    #
-    print('single_state_ARIs:')
-    print(single_state_ARIs)
-    #
-    print('multi_state_mean_test_lls:')
-    print(multi_state_mean_test_lls)
-    #
-    print('multi_state_ARIs:')
-    print(multi_state_ARIs)

--- a/src/cython_code/State.pyx
+++ b/src/cython_code/State.pyx
@@ -26,6 +26,7 @@ from libcpp.set cimport set as c_set
 from cython.operator import dereference
 cimport numpy as np
 #
+import collections
 import numpy
 import six
 #
@@ -371,8 +372,11 @@ cdef class p_State:
     # mutators
     def insert_row(self, row_data, matching_row_idx, row_idx=-1):
         return self.thisptr.insert_row(row_data, matching_row_idx, row_idx)
-    def transition(self, which_transitions=(), n_steps=1,
-                   c=(), r=(), max_iterations=-1, max_time=-1, progress=None):
+    def transition(
+            self, which_transitions=(), n_steps=1, c=(), r=(),
+            max_iterations=-1, max_time=-1, progress=None,
+            diagnostic_func_dict=None, diagnostics_dict=None,
+            diagnostics_every_N=None,):
          def _progress(percentage):
               import sys
               progress = ' ' * 30
@@ -384,6 +388,10 @@ cdef class p_State:
               p_seconds = elapsed / S if S != -1 else 0
               p_iters = float(iters) / N
               return max(p_iters, p_seconds)
+         if diagnostics_dict is None:
+            diagnostics_dict = collections.defaultdict(list)
+         if diagnostic_func_dict is None:
+            diagnostic_func_dict = dict()
          seed = None
          score_delta = 0
          if len(which_transitions) == 0:
@@ -412,6 +420,13 @@ cdef class p_State:
                              print(print_str)
                    else:
                         step_idx += 1
+                        if (diagnostics_every_N) and \
+                            (step_idx % diagnostics_every_N == 0):
+                          for diagnostic_name, diagnostic_func in\
+                                  six.iteritems(diagnostic_func_dict):
+                              diagnostic_value = diagnostic_func(self)
+                              diagnostics_dict[diagnostic_name].append(
+                                diagnostic_value)
                         continue
                    if progress:
                      print(

--- a/src/tests/crosscat_client_runner.py
+++ b/src/tests/crosscat_client_runner.py
@@ -1,0 +1,44 @@
+#   Copyright (c) 2010-2016, MIT Probabilistic Computing Project
+#
+#   Lead Developers: Dan Lovell and Jay Baxter
+#   Authors: Dan Lovell, Baxter Eaves, Jay Baxter, Vikash Mansinghka
+#   Research Leads: Vikash Mansinghka, Patrick Shafto
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import random
+
+import crosscat.utils.data_utils as du
+from crosscat.CrossCatClient import get_CrossCatClient
+
+ccc = get_CrossCatClient('local', seed=0)
+
+gen_seed = 0
+num_clusters = 4
+num_cols = 8
+num_rows = 16
+num_splits = 1
+max_mean = 10
+max_std = 0.1
+rng = random.Random(gen_seed)
+get_next_seed = lambda: rng.randint(1, 2**31 - 1)
+T, M_r, M_c = du.gen_factorial_data_objects(
+    get_next_seed(), num_clusters,
+    num_cols, num_rows, num_splits,
+    max_mean=max_mean, max_std=max_std,
+    )
+
+X_L, X_D, = ccc.initialize(M_c, M_r, T, get_next_seed())
+X_L_prime, X_D_prime = ccc.analyze(M_c, T, X_L, X_D, get_next_seed())
+X_L_prime, X_D_prime = ccc.analyze(M_c, T, X_L_prime, X_D_prime,
+    get_next_seed())

--- a/src/tests/multiprocessing_engine_runner.py
+++ b/src/tests/multiprocessing_engine_runner.py
@@ -1,0 +1,79 @@
+#   Copyright (c) 2010-2016, MIT Probabilistic Computing Project
+#
+#   Lead Developers: Dan Lovell and Jay Baxter
+#   Authors: Dan Lovell, Baxter Eaves, Jay Baxter, Vikash Mansinghka
+#   Research Leads: Vikash Mansinghka, Patrick Shafto
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import random
+
+import crosscat.utils.convergence_test_utils as ctu
+import crosscat.utils.data_utils as du
+
+from crosscat.MultiprocessingEngine import MultiprocessingEngine
+
+# settings
+gen_seed = 0
+inf_seed = 0
+num_clusters = 4
+num_cols = 32
+num_rows = 400
+num_views = 2
+n_steps = 1
+n_times = 5
+n_chains = 3
+n_test = 100
+rng = random.Random(gen_seed)
+get_next_seed = lambda: rng.randint(1, 2**31 - 1)
+
+# generate some data
+T, M_r, M_c, data_inverse_permutation_indices = du.gen_factorial_data_objects(
+        get_next_seed(), num_clusters, num_cols, num_rows, num_views,
+        max_mean=100, max_std=1, send_data_inverse_permutation_indices=True)
+
+view_assignment_truth, X_D_truth = ctu.truth_from_permute_indices(
+        data_inverse_permutation_indices, num_rows, num_cols,
+        num_views, num_clusters)
+
+X_L_gen, X_D_gen = du.get_generative_clustering(get_next_seed(),
+        M_c, M_r, T, data_inverse_permutation_indices, num_clusters, num_views)
+T_test = ctu.create_test_set(M_c, T, X_L_gen, X_D_gen, n_test, seed_seed=0)
+
+#
+generative_mean_test_log_likelihood = ctu.calc_mean_test_log_likelihood(M_c, T,
+        X_L_gen, X_D_gen, T_test)
+
+# run some tests
+engine = MultiprocessingEngine()
+
+# single state test
+single_state_ARIs = []
+single_state_mean_test_lls = []
+X_L, X_D = engine.initialize(M_c, M_r, T, get_next_seed(), n_chains=1)
+single_state_ARIs.append(ctu.get_column_ARI(X_L, view_assignment_truth))
+single_state_mean_test_lls.append(
+    ctu.calc_mean_test_log_likelihood(M_c, T, X_L, X_D, T_test))
+
+for time_i in range(n_times):
+    X_L, X_D = engine.analyze(M_c, T, X_L, X_D, get_next_seed(),
+        n_steps=n_steps)
+    single_state_ARIs.append(ctu.get_column_ARI(X_L, view_assignment_truth))
+    single_state_mean_test_lls.append(
+        ctu.calc_mean_test_log_likelihood(M_c, T, X_L, X_D, T_test))
+
+# multistate test
+multi_state_ARIs = []
+multi_state_mean_test_lls = []
+X_L_list, X_D_list = engine.initialize(
+    M_c, M_r, T, get_next_seed(), n_chains=n_chains)

--- a/src/utils/sample_utils.py
+++ b/src/utils/sample_utils.py
@@ -16,21 +16,25 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-#
-from six.moves import range
+
+
 import copy
-from collections import Counter
-import numpy
 import itertools
+import numpy
 import six
-#
+
+from collections import Counter
+from six.moves import range
+
 import crosscat.cython_code.ContinuousComponentModel as CCM
-import crosscat.cython_code.MultinomialComponentModel as MCM
 import crosscat.cython_code.CyclicComponentModel as CYCM
-import crosscat.utils.general_utils as gu
+import crosscat.cython_code.MultinomialComponentModel as MCM
 import crosscat.utils.data_utils as du
-from crosscat.utils.general_utils import logsumexp
+import crosscat.utils.general_utils as gu
+
 from crosscat.utils.general_utils import logmeanexp
+from crosscat.utils.general_utils import logsumexp
+
 
 class Bunch(dict):
     def __getattr__(self, key):
@@ -41,7 +45,9 @@ class Bunch(dict):
     def __setattr__(self, key, value):
         self[key] = value
 
+
 Constraints = Bunch
+
 
 def predictive_probability(M_c, X_L, X_D, Y, Q):
     # Evaluates the joint logpdf of crosscat columns. This is acheived by
@@ -128,10 +134,10 @@ def simple_predictive_probability(M_c, X_L, X_D, Y, Q):
     return x
 
 
-def simple_predictive_probability_observed(M_c, X_L, X_D, Y, query_row,
-                                      query_columns, elements):
-    n_queries = len(query_columns)
+def simple_predictive_probability_observed(
+        M_c, X_L, X_D, Y, query_row, query_columns, elements):
 
+    n_queries = len(query_columns)
     answer = numpy.zeros(n_queries)
 
     for n in range(n_queries):
@@ -143,94 +149,100 @@ def simple_predictive_probability_observed(M_c, X_L, X_D, Y, query_row,
         # get cluster
         cluster_idx = X_D[view_idx][query_row]
         # get the cluster model for this cluster
-        cluster_model = create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx)
+        cluster_model = create_cluster_model_from_X_L(
+            M_c, X_L, view_idx, cluster_idx)
         # get the specific cluster model for this column
         component_model = cluster_model[query_column]
         # construct draw conataints
-        draw_constraints = get_draw_constraints(X_L, X_D, Y, query_row, query_column)
-
+        draw_constraints = get_draw_constraints(
+            X_L, X_D, Y, query_row, query_column)
         # return the PDF value (exp)
-        p_x = component_model.calc_element_predictive_logp_constrained(x, draw_constraints)
+        p_x = component_model.calc_element_predictive_logp_constrained(
+            x, draw_constraints)
 
         answer[n] = p_x
 
     return answer
 
-def simple_predictive_probability_unobserved(M_c, X_L, X_D, Y, query_row, query_columns, elements):
+
+def simple_predictive_probability_unobserved(
+        M_c, X_L, X_D, Y, query_row, query_columns, elements):
 
     n_queries = len(query_columns)
-
     answer = numpy.zeros(n_queries)
-    # answers = numpy.array([])
 
     for n in range(n_queries):
         query_column = query_columns[n]
         x = elements[n]
 
-        # get the view to which this column is assigned
+        # Get the view to which this column is assigned.
         view_idx = X_L['column_partition']['assignments'][query_column]
-        # get the logps for all the clusters (plus a new one) in this view
-        cluster_logps = determine_cluster_logps(M_c, X_L, X_D, Y, query_row, view_idx)
+        # Get the logps for all the clusters (plus a new one) in this view.
+        cluster_logps = determine_cluster_logps(
+            M_c, X_L, X_D, Y, query_row, view_idx)
 
         answers_n = numpy.zeros(len(cluster_logps))
 
-        # cluster_logps should logsumexp to log(1)
+        # `cluster_logps` should logsumexp to log(1).
         assert numpy.abs(logsumexp(cluster_logps)) < .0000001
 
-        # enumerate over the clusters
+        # Enumerate over the clusters
         for cluster_idx in range(len(cluster_logps)):
 
-            # get the cluster model for this cluster
-            cluster_model = create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx)
-            # get the specific cluster model for this column
+            # Get the cluster model for this cluster.
+            cluster_model = create_cluster_model_from_X_L(
+                M_c, X_L, view_idx, cluster_idx)
+            # Get the specific cluster model for this column.
             component_model = cluster_model[query_column]
-            # construct draw conataints
-            draw_constraints = get_draw_constraints(X_L, X_D, Y, query_row, query_column)
+            # Construct draw conataints.
+            draw_constraints = get_draw_constraints(
+                X_L, X_D, Y, query_row, query_column)
 
-            # return the PDF value (exp)
-            p_x = component_model.calc_element_predictive_logp_constrained(x, draw_constraints)
+            # Return the PDF value (exp).
+            p_x = component_model.calc_element_predictive_logp_constrained(
+                x, draw_constraints)
 
-
-            answers_n[cluster_idx] = p_x+cluster_logps[cluster_idx]
+            answers_n[cluster_idx] = p_x + cluster_logps[cluster_idx]
 
         answer[n] = logsumexp(answers_n)
 
     return answer
 
-##############################################################################
 
 def row_structural_typicality(X_L_list, X_D_list, row_id):
-    """
-    Returns how typical the row is (opposite of how anomalous the row is).
-    """
+    """Returns how typical the row is (opposite of how anomalous)."""
     count = 0
     assert len(X_L_list) == len(X_D_list)
     for X_L, X_D in zip(X_L_list, X_D_list):
         for r in range(len(X_D[0])):
-            for c in range(len(X_L['column_partition']['assignments'])):
-                if X_D[X_L['column_partition']['assignments'][c]][r] == X_D[X_L['column_partition']['assignments'][c]][row_id]:
+            for c in range(
+                    len(X_L['column_partition']['assignments'])):
+                if X_D[X_L['column_partition']['assignments'][c]][r] == \
+                        X_D[X_L['column_partition']['assignments'][c]][row_id]:
                     count += 1
-    return float(count) / (len(X_D_list) * len(X_D[0]) * len(X_L_list[0]['column_partition']['assignments']))
+    return float(count) / \
+        (len(X_D_list) * len(X_D[0]) *
+            len(X_L_list[0]['column_partition']['assignments']))
 
 
 def column_structural_typicality(X_L_list, col_id):
-    """
-    Returns how typical the column is (opposite of how anomalous the column is).
-    """
+    """Returns how typical column is (opposite of how anomalous)."""
     count = 0
     for X_L in X_L_list:
         for c in range(len(X_L['column_partition']['assignments'])):
-            if X_L['column_partition']['assignments'][col_id] == X_L['column_partition']['assignments'][c]:
+            if X_L['column_partition']['assignments'][col_id] ==\
+                    X_L['column_partition']['assignments'][c]:
                 count += 1
-    return float(count) / (len(X_L_list) * len(X_L_list[0]['column_partition']['assignments']))
+    return float(count) / \
+        (len(X_L_list) * len(X_L_list[0]['column_partition']['assignments']))
+
 
 def simple_predictive_probability_multistate(M_c, X_L_list, X_D_list, Y, Q):
-    """
-    Returns the simple predictive probability, averaged over each sample.
-    """
+    """Returns the simple predictive probability, averaged over each sample."""
     logprobs = [float(simple_predictive_probability(M_c, X_L, X_D, Y, Q))
         for X_L, X_D in zip(X_L_list, X_D_list)]
     return logmeanexp(logprobs)
+
 
 def predictive_probability_multistate(M_c, X_L_list, X_D_list, Y, Q):
     """
@@ -241,18 +253,18 @@ def predictive_probability_multistate(M_c, X_L_list, X_D_list, Y, Q):
     return logmeanexp(logprobs)
 
 
-#############################################################################
-
-def similarity(M_c, X_L_list, X_D_list, given_row_id, target_row_id, target_column=None):
-    """
-    Returns the similarity of the given row to the target row, averaged over
+def similarity(
+        M_c, X_L_list, X_D_list, given_row_id, target_row_id,
+        target_column=None):
+    """Returns the similarity of the given row to the target row, averaged over
     all the column indexes given by col_idxs.
+
     Similarity is defined as the proportion of times that two cells are in the same
     view and category.
     """
     score = 0.0
 
-    ## Set col_idxs: defaults to all columns.
+    # Set col_idxs: defaults to all columns.
     if target_column:
         if type(target_column) == str:
             col_idxs = [M_c['name_to_idx'][target_column]]
@@ -270,19 +282,18 @@ def similarity(M_c, X_L_list, X_D_list, given_row_id, target_row_id, target_colu
             view_idx = X_L['column_partition']['assignments'][col_idx]
             if X_D[view_idx][given_row_id] == X_D[view_idx][target_row_id]:
                 score += 1.0
+
     return score / (len(X_L_list)*len(col_idxs))
 
-################################################################################
-################################################################################
 
 def simple_predictive_sample(M_c, X_L, X_D, Y, Q, get_next_seed, n=1):
     num_rows = len(X_D[0])
     num_cols = len(M_c['column_metadata'])
     query_row = Q[0][0]
     query_columns = [query[1] for query in Q]
-    # enforce query rows all same row
+    # Enforce query rows all same row.
     assert all([query[0]==query_row for query in Q])
-    # enforce query columns observed column
+    # Enforce query columns observed column.
     assert all([query_column<num_cols for query_column in query_columns])
     is_observed_row = query_row < num_rows
     x = []
@@ -292,42 +303,35 @@ def simple_predictive_sample(M_c, X_L, X_D, Y, Q, get_next_seed, n=1):
     else:
         x = simple_predictive_sample_observed(
             M_c, X_L, X_D, Y, query_row, query_columns, get_next_seed, n)
-    # # more modular logic
-    # observed_view_cluster_tuples = ()
-    # if is_observed_row:
-    #     observed_view_cluster_tuples = get_view_cluster_tuple(
-    #         M_c, X_L, X_D, query_row)
-    #     observed_view_cluster_tuples = [observed_view_cluster_tuples] * n
-    # else:
-    #     view_cluster_logps = determine_view_cluster_logps(
-    #         M_c, X_L, X_D, Y, query_row)
-    #     observed_view_cluster_tuples = \
-    #         sample_view_cluster_tuples_from_logp(view_cluster_logps, n)
-    # x = draw_from_view_cluster_tuples(M_c, X_L, X_D, Y,
-    #                                   observed_view_cluster_tuples)
     return x
 
-def simple_predictive_sample_multistate(M_c, X_L_list, X_D_list, Y, Q,
-                                        get_next_seed, n=1):
+
+def simple_predictive_sample_multistate(
+        M_c, X_L_list, X_D_list, Y, Q, get_next_seed, n=1):
+
     num_states = len(X_L_list)
     assert num_states==len(X_D_list)
     n_from_each = n / num_states
     n_sampled = n % num_states
+
     random_state = numpy.random.RandomState(get_next_seed())
     which_sampled = random_state.permutation(range(num_states))[:n_sampled]
     which_sampled = set(which_sampled)
+
     x = []
     for state_idx, (X_L, X_D) in enumerate(zip(X_L_list, X_D_list)):
         this_n = n_from_each
         if state_idx in which_sampled:
             this_n += 1
-        this_x = simple_predictive_sample(M_c, X_L, X_D, Y, Q,
-                                          get_next_seed, this_n)
+        this_x = simple_predictive_sample(
+            M_c, X_L, X_D, Y, Q, get_next_seed, this_n)
         x.extend(this_x)
+
     return x
 
-def simple_predictive_sample_observed(M_c, X_L, X_D, Y, which_row,
-                                      which_columns, get_next_seed, n=1):
+
+def simple_predictive_sample_observed(
+        M_c, X_L, X_D, Y, which_row, which_columns, get_next_seed, n=1):
     # Reject attempts to query columns on which we are conditioned for
     # this observed row.  This amounts to asking Crosscat to predict
     # what value a column C would hold in an observed row, if it had a
@@ -342,7 +346,7 @@ def simple_predictive_sample_observed(M_c, X_L, X_D, Y, which_row,
     constrained_columns = set(col for row, col, _val in Y if row == which_row)
     assert not set(c for c in which_columns if c in constrained_columns), \
         'Query for constrained column in observed row makes no sense!'
-    #
+
     def view_for(column):
         return X_L['column_partition']['assignments'][column]
     def cluster_model_for(view):
@@ -351,18 +355,21 @@ def simple_predictive_sample_observed(M_c, X_L, X_D, Y, which_row,
         return create_cluster_model_from_X_L(M_c, X_L, view, cluster)
     def component_model_for(column):
         return cluster_model_for(view_for(column))[column]
+
     samples_list = []
     for _ in range(n):
         this_sample_draws = []
         for which_column in which_columns:
             component_model = component_model_for(which_column)
-            draw_constraints = get_draw_constraints(X_L, X_D, Y,
-                                                    which_row, which_column)
+            draw_constraints = get_draw_constraints(
+                X_L, X_D, Y, which_row, which_column)
             SEED = get_next_seed()
             draw = component_model.get_draw_constrained(SEED,draw_constraints)
             this_sample_draws.append(draw)
         samples_list.append(this_sample_draws)
+
     return samples_list
+
 
 def names_to_global_indices(column_names, M_c):
     name_to_idx = M_c['name_to_idx']
@@ -371,6 +378,7 @@ def names_to_global_indices(column_names, M_c):
     if isinstance(first_key, (six.text_type, six.binary_type)):
        column_names = map(str, column_names)
     return [name_to_idx[column_name] for column_name in column_names]
+
 
 def extract_view_column_info(M_c, X_L, view_idx):
     view_state_i = X_L['view_state'][view_idx]
@@ -386,11 +394,12 @@ def extract_view_column_info(M_c, X_L, view_idx):
             X_L['column_hypers'][col_idx]
             for col_idx in global_column_indices
             ])
-    zipped_column_info = zip(column_metadata, column_hypers,
-                             column_component_suffstats)
+    zipped_column_info = zip(
+        column_metadata, column_hypers, column_component_suffstats)
     zipped_column_info = dict(zip(global_column_indices, zipped_column_info))
     row_partition_model = view_state_i['row_partition_model']
     return zipped_column_info, row_partition_model
+
 
 def get_column_info_subset(zipped_column_info, column_indices):
     column_info_subset = dict()
@@ -399,6 +408,7 @@ def get_column_info_subset(zipped_column_info, column_indices):
             column_info_subset[column_index] = \
                 zipped_column_info[column_index]
     return column_info_subset
+
 
 def create_component_model(column_metadata, column_hypers, suffstats):
     modeltype = column_metadata['modeltype']
@@ -426,9 +436,11 @@ def create_component_model(column_metadata, column_hypers, suffstats):
         raise ValueError('unknown modeltype: %r' % (modeltype,))
     return component_model
 
-def create_cluster_model(zipped_column_info, row_partition_model,
-                         cluster_idx):
+
+def create_cluster_model(
+        zipped_column_info, row_partition_model, cluster_idx):
     cluster_component_models = dict()
+
     for global_column_idx in zipped_column_info:
         column_metadata, column_hypers, column_component_suffstats = \
             zipped_column_info[global_column_idx]
@@ -436,60 +448,77 @@ def create_cluster_model(zipped_column_info, row_partition_model,
         component_model = create_component_model(
             column_metadata, column_hypers, cluster_component_suffstats)
         cluster_component_models[global_column_idx] = component_model
+
     return cluster_component_models
+
 
 def create_empty_cluster_model(zipped_column_info):
     cluster_component_models = dict()
+
     for global_column_idx in zipped_column_info:
         column_metadata, column_hypers, _column_component_suffstats = \
             zipped_column_info[global_column_idx]
-        component_model = create_component_model(column_metadata,
-                                                 column_hypers, {b'N': None})
+        component_model = create_component_model(
+            column_metadata, column_hypers, {b'N': None})
         cluster_component_models[global_column_idx] = component_model
+
     return cluster_component_models
+
 
 def create_cluster_models(M_c, X_L, view_idx, which_columns=None):
     zipped_column_info, row_partition_model = extract_view_column_info(
         M_c, X_L, view_idx)
+
     if which_columns is not None:
         zipped_column_info = get_column_info_subset(
             zipped_column_info, which_columns)
     num_clusters = len(row_partition_model['counts'])
+
     cluster_models = []
     for cluster_idx in range(num_clusters):
         cluster_model = create_cluster_model(
-            zipped_column_info, row_partition_model, cluster_idx
-            )
+            zipped_column_info, row_partition_model, cluster_idx)
         cluster_models.append(cluster_model)
     empty_cluster_model = create_empty_cluster_model(zipped_column_info)
     cluster_models.append(empty_cluster_model)
+
     return cluster_models
 
-def determine_cluster_data_logp(cluster_model, cluster_sampling_constraints,
-                                X_D_i, cluster_idx):
+
+def determine_cluster_data_logp(
+        cluster_model, cluster_sampling_constraints, X_D_i, cluster_idx):
     logp = 0
+
     for column_idx, column_constraint_dict \
             in six.iteritems(cluster_sampling_constraints):
+
         if column_idx in cluster_model:
             other_constraint_values = []
+
             for other_row, other_value in column_constraint_dict['others']:
                 if X_D_i[other_row]==cluster_idx:
                     other_constraint_values.append(other_value)
+
             this_constraint_value = column_constraint_dict['this']
             component_model = cluster_model[column_idx]
             logp += component_model.calc_element_predictive_logp_constrained(
                 this_constraint_value, other_constraint_values)
+
     return logp
+
 
 def get_cluster_sampling_constraints(Y, query_row):
     constraint_dict = dict()
+
     if Y is not None:
+
         for constraint in Y:
             constraint_row, constraint_col, constraint_value = constraint
             is_same_row = constraint_row == query_row
             if is_same_row:
                 constraint_dict[constraint_col] = dict(this=constraint_value)
                 constraint_dict[constraint_col]['others'] = []
+
         for constraint in Y:
             constraint_row, constraint_col, constraint_value = constraint
             is_same_row = constraint_row == query_row
@@ -497,18 +526,23 @@ def get_cluster_sampling_constraints(Y, query_row):
             if is_same_col and not is_same_row:
                 other = (constraint_row, constraint_value)
                 constraint_dict[constraint_col]['others'].append(other)
+
     return constraint_dict
+
 
 def get_draw_constraints(X_L, X_D, Y, draw_row, draw_column):
     constraint_values = []
+
     if Y is not None:
         column_partition_assignments = X_L['column_partition']['assignments']
         view_idx = column_partition_assignments[draw_column]
         X_D_i = X_D[view_idx]
+
         try:
             draw_cluster = X_D_i[draw_row]
         except IndexError:
             draw_cluster = None
+
         for constraint in Y:
             constraint_row, constraint_col, constraint_value = constraint
             try:
@@ -518,21 +552,28 @@ def get_draw_constraints(X_L, X_D, Y, draw_row, draw_column):
             if (constraint_col == draw_column) \
                     and (constraint_cluster == draw_cluster):
                 constraint_values.append(constraint_value)
+
     return constraint_values
+
 
 def determine_cluster_data_logps(M_c, X_L, X_D, Y, query_row, view_idx):
     logps = []
     cluster_sampling_constraints = \
         get_cluster_sampling_constraints(Y, query_row)
     relevant_constraint_columns = cluster_sampling_constraints.keys()
-    cluster_models = create_cluster_models(M_c, X_L, view_idx,
-                                           relevant_constraint_columns)
+
+    cluster_models = create_cluster_models(
+        M_c, X_L, view_idx, relevant_constraint_columns)
+
     X_D_i = X_D[view_idx]
+
     for cluster_idx, cluster_model in enumerate(cluster_models):
         logp = determine_cluster_data_logp(
             cluster_model, cluster_sampling_constraints, X_D_i, cluster_idx)
         logps.append(logp)
+
     return logps
+
 
 def determine_cluster_crp_logps(view_state_i):
     counts = view_state_i['row_partition_model']['counts']
@@ -542,12 +583,13 @@ def determine_cluster_crp_logps(view_state_i):
     logps = numpy.log(counts_appended / float(sum_counts_appended))
     return logps
 
+
 def determine_cluster_logps(M_c, X_L, X_D, Y, query_row, view_idx):
     view_state_i = X_L['view_state'][view_idx]
     cluster_crp_logps = determine_cluster_crp_logps(view_state_i)
     cluster_crp_logps = numpy.array(cluster_crp_logps)
-    cluster_data_logps = determine_cluster_data_logps(M_c, X_L, X_D, Y,
-                                                      query_row, view_idx)
+    cluster_data_logps = determine_cluster_data_logps(
+        M_c, X_L, X_D, Y, query_row, view_idx)
     cluster_data_logps = numpy.array(cluster_data_logps)
     # We need to compute the vector of probabilities log[P(Z=j|Y)] where `Z`
     # is the row cluster, `Y` are the constraints, and `j` iterates from 1 to
@@ -565,6 +607,7 @@ def determine_cluster_logps(M_c, X_L, X_D, Y, query_row, view_idx):
 
     return cluster_logps
 
+
 def sample_from_cluster(cluster_model, random_state):
     sample = []
     for column_index in sorted(cluster_model.keys()):
@@ -573,6 +616,7 @@ def sample_from_cluster(cluster_model, random_state):
         sample_i = component_model.get_draw(seed_i)
         sample.append(sample_i)
     return sample
+
 
 # LRU replacement, size 1
 __cache = (-1, None)
@@ -586,6 +630,7 @@ def _cache_for(M_c):
         __cache = (id(M_c), ans)
         return ans
 
+
 def create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx):
     cache = _cache_for(M_c)
     key = ('cluster_model', id(X_L), view_idx, cluster_idx)
@@ -596,36 +641,40 @@ def create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx):
         cache[key] = ans
         return ans
 
+
 def do_create_cluster_model_from_X_L(M_c, X_L, view_idx, cluster_idx):
     zipped_column_info, row_partition_model = extract_view_column_info(
         M_c, X_L, view_idx)
     num_clusters = len(row_partition_model['counts'])
     if cluster_idx==num_clusters:
-        # drew a new cluster
+        # Drew a new cluster.
         return create_empty_cluster_model(zipped_column_info)
     else:
         return create_cluster_model(
             zipped_column_info, row_partition_model, cluster_idx)
 
-def simple_predictive_sample_unobserved(M_c, X_L, X_D, Y, query_row,
-                                        query_columns, get_next_seed, n=1):
+
+def simple_predictive_sample_unobserved(
+        M_c, X_L, X_D, Y, query_row, query_columns, get_next_seed, n=1):
     num_views = len(X_D)
     random_state = numpy.random.RandomState(get_next_seed())
-    #
+
     cluster_logps_list = []
-    # for each view
+    # For each view.
     for view_idx in range(num_views):
-        # get the logp of the cluster of query_row in this view
-        cluster_logps = determine_cluster_logps(M_c, X_L, X_D, Y, query_row,
-                                                view_idx)
+        # Get the logp of the cluster of query_row in this view.
+        cluster_logps = determine_cluster_logps(
+            M_c, X_L, X_D, Y, query_row, view_idx)
         cluster_logps_list.append(cluster_logps)
-    #
+
     query_row_constraints = dict() if Y is None else \
         dict((col, val) for row, col, val in Y if row == query_row)
+
     def view_for(column):
         return X_L['column_partition']['assignments'][column]
     def cluster_model_for(view, cluster):
         return create_cluster_model_from_X_L(M_c, X_L, view, cluster)
+
     samples_list = []
     for _ in range(n):
         view_cluster_draws = dict()
@@ -634,10 +683,11 @@ def simple_predictive_sample_unobserved(M_c, X_L, X_D, Y, query_row,
             probs /= sum(probs)
             draw = numpy.nonzero(random_state.multinomial(1, probs))[0][0]
             view_cluster_draws[view_idx] = draw
-        #
+
         def component_model_for(column):
             view = view_for(column)
             return cluster_model_for(view, view_cluster_draws[view])[column]
+
         this_sample_draws = []
         for query_column in query_columns:
             # If the caller specified this column in the constraints,
@@ -652,13 +702,14 @@ def simple_predictive_sample_unobserved(M_c, X_L, X_D, Y, query_row,
                 draw = query_row_constraints[query_column]
             else:
                 component_model = component_model_for(query_column)
-                draw_constraints = get_draw_constraints(X_L, X_D, Y,
-                                                        query_row, query_column)
+                draw_constraints = get_draw_constraints(
+                    X_L, X_D, Y, query_row, query_column)
                 SEED = get_next_seed()
-                draw = component_model.get_draw_constrained(SEED,
-                                                            draw_constraints)
+                draw = component_model.get_draw_constrained(
+                    SEED, draw_constraints)
             this_sample_draws.append(draw)
         samples_list.append(this_sample_draws)
+
     return samples_list
 
 
@@ -667,6 +718,7 @@ def multinomial_imputation_confidence(samples, imputed, column_hypers_i):
     confidence = float(max_count) / len(samples)
     return confidence
 
+
 def get_continuous_mass_within_delta(samples, center, delta):
     num_samples = len(samples)
     num_within_delta = sum(numpy.abs(samples - center) < delta)
@@ -674,10 +726,9 @@ def get_continuous_mass_within_delta(samples, center, delta):
     return mass_fraction
 
 
-def continuous_imputation_confidence(samples, imputed,
-                                     column_component_suffstats_i,
-                                     n_steps=100, n_chains=1,
-                                     return_metadata=False):
+def continuous_imputation_confidence(
+        samples, imputed, column_component_suffstats_i, n_steps=100,
+        n_chains=1, return_metadata=False):
     # XXX: the confidence in continuous imputation is "the probability that
     # there exists a unimodal summary" which is defined as the proportion of
     # probability mass in the largest mode of a DPMM inferred from the simulate
@@ -765,6 +816,7 @@ def continuous_imputation(samples, get_next_seed):
     imputed = numpy.median(samples)
     return imputed
 
+
 def multinomial_imputation(samples, get_next_seed):
     counter = Counter(samples)
     max_tuple = counter.most_common(1)[0]
@@ -781,37 +833,44 @@ def multinomial_imputation(samples, get_next_seed):
         imputed = values[draw]
     return imputed
 
+
 # FIXME: ensure callers aren't passing continuous, multinomial
 modeltype_to_imputation_function = {
     'normal_inverse_gamma': continuous_imputation,
     'symmetric_dirichlet_discrete': multinomial_imputation,
     }
 
+
 modeltype_to_imputation_confidence_function = {
     'normal_inverse_gamma': continuous_imputation_confidence,
     'symmetric_dirichlet_discrete': multinomial_imputation_confidence,
     }
 
+
 def impute(M_c, X_L, X_D, Y, Q, n, get_next_seed, return_samples=False):
     # FIXME: allow more than one cell to be imputed
     assert len(Q)==1
-    #
+
     col_idx = Q[0][1]
     modeltype = M_c['column_metadata'][col_idx]['modeltype']
     assert modeltype in modeltype_to_imputation_function
+
     if get_is_multistate(X_L, X_D):
-        samples = simple_predictive_sample_multistate(M_c, X_L, X_D, Y, Q,
-                                           get_next_seed, n)
+        samples = simple_predictive_sample_multistate(
+            M_c, X_L, X_D, Y, Q, get_next_seed, n)
     else:
-        samples = simple_predictive_sample(M_c, X_L, X_D, Y, Q,
-                                           get_next_seed, n)
+        samples = simple_predictive_sample(
+            M_c, X_L, X_D, Y, Q, get_next_seed, n)
+
     samples = numpy.array(samples).T[0]
     imputation_function = modeltype_to_imputation_function[modeltype]
     e = imputation_function(samples, get_next_seed)
+
     if return_samples:
         return e, samples
     else:
         return e
+
 
 def get_confidence_interval(imputed, samples, confidence=.5):
     deltas = numpy.array(samples) - imputed
@@ -823,16 +882,20 @@ def get_confidence_interval(imputed, samples, confidence=.5):
     interval = numpy.mean([lower_value, upper_value])
     return interval
 
+
 def get_column_std(column_component_suffstats_i):
     N = sum(map(gu.get_getname('N'), column_component_suffstats_i))
     sum_x = sum(map(gu.get_getname('sum_x'), column_component_suffstats_i))
-    sum_x_squared = sum(map(gu.get_getname('sum_x_squared'), column_component_suffstats_i))
-    #
+    sum_x_squared = sum(map(
+        gu.get_getname('sum_x_squared'), column_component_suffstats_i))
+
     exp_x = sum_x / float(N)
     exp_x_squared = sum_x_squared / float(N)
     col_var = exp_x_squared - (exp_x ** 2)
     col_std = col_var ** .5
+
     return col_std
+
 
 def get_column_component_suffstats_i(M_c, X_L, col_idx):
     column_name = M_c['idx_to_name'][str(col_idx)]
@@ -843,6 +906,7 @@ def get_column_component_suffstats_i(M_c, X_L, col_idx):
         view_state_i['column_component_suffstats'][local_col_idx]
     return column_component_suffstats_i
 
+
 def impute_and_confidence(M_c, X_L, X_D, Y, Q, n, get_next_seed):
     # FIXME: allow more than one cell to be imputed
     assert len(Q)==1
@@ -850,18 +914,19 @@ def impute_and_confidence(M_c, X_L, X_D, Y, Q, n, get_next_seed):
     modeltype = M_c['column_metadata'][col_idx]['modeltype']
     imputation_confidence_function = \
         modeltype_to_imputation_confidence_function[modeltype]
-    #
-    imputed, samples = impute(M_c, X_L, X_D, Y, Q, n, get_next_seed,
-                        return_samples=True)
+
+    imputed, samples = impute(
+        M_c, X_L, X_D, Y, Q, n, get_next_seed, return_samples=True)
     if get_is_multistate(X_L, X_D):
         X_L = X_L[0]
         X_D = X_D[0]
     column_component_suffstats_i = \
         get_column_component_suffstats_i(M_c, X_L, col_idx)
     imputation_confidence = \
-        imputation_confidence_function(samples, imputed,
-                                       column_component_suffstats_i)
+        imputation_confidence_function(
+            samples, imputed, column_component_suffstats_i)
     return imputed, imputation_confidence
+
 
 def determine_replicating_samples_params(X_L, X_D):
     view_assignments_array = X_L['column_partition']['assignments']
@@ -889,6 +954,7 @@ def determine_replicating_samples_params(X_L, X_D):
         views_replicating_samples.append(this_view_replicating_samples)
     return views_replicating_samples
 
+
 def get_is_multistate(X_L, X_D):
     if isinstance(X_L, (list, tuple)):
         assert isinstance(X_D, (list, tuple))
@@ -896,6 +962,7 @@ def get_is_multistate(X_L, X_D):
         return True
     else:
         return False
+
 
 def ensure_multistate(X_L_list, X_D_list):
     was_multistate = get_is_multistate(X_L_list, X_D_list)
@@ -907,16 +974,3 @@ def ensure_multistate(X_L_list, X_D_list):
     # FIXME: The culprits are likely sparsify_X_L and desparsify_X_L in
     # State.pyx
     return copy.deepcopy(X_L_list), copy.deepcopy(X_D_list), was_multistate
-
-# def determine_cluster_view_logps(M_c, X_L, X_D, Y):
-#     get_which_view = lambda which_column: \
-#         X_L['column_partition']['assignments'][which_column]
-#     column_to_view = dict()
-#     for which_column in which_columns:
-#         column_to_view[which_column] = get_which_view(which_column)
-#     num_views = len(X_D)
-#     cluster_logps_list = []
-#     for view_idx in range(num_views):
-#         cluster_logps = determine_cluster_logps(M_c, X_L, X_D, Y, view_idx)
-#         cluster_logps_list.append(cluster_logp)
-#     return cluster_view_logps


### PR DESCRIPTION
Moves recording of diagnostics from `LocalEngine.py` to `State.pyx`
Two reasons for this commit:
(i) The current implementation of diagnostic recording fails when the user
specifies a `max_time` with `diagnostics_every_N`. This is beacuse _each invocation
of p_State.transition uses the same `max_time` inside the for loop over
`child_n_steps`, whereas we really need `max_time` to apply to the union of
calls to p_State.transition.

(ii) The progress bar is now compatible with diagnostic recording, which
occurs in the inner loop of State.transition.

Parent PR is 20160920-fsaad-fixup.
